### PR TITLE
Remove custom types from core

### DIFF
--- a/src/bindings/python/src/pyopenvino/frontend/pytorch/decoder.cpp
+++ b/src/bindings/python/src/pyopenvino/frontend/pytorch/decoder.cpp
@@ -35,5 +35,7 @@ void regclass_frontend_pytorch_decoder(py::module m) {
         def(py::init<Any>());
     py::class_<Type::List>(type_module, "List").
         def(py::init<Any>());
+    py::class_<Type::Str>(type_module, "Str").
+        def(py::init<>());
     type_module.def("print", Type::print);
 }

--- a/src/core/builder/include/ngraph/builder/make_constant.hpp
+++ b/src/core/builder/include/ngraph/builder/make_constant.hpp
@@ -95,8 +95,6 @@ std::shared_ptr<Node> make_constant(const element::Type& type, const Shape& shap
         throw ngraph_error("make_constant: Unsupported element type 'u4'");
     case element::Type_t::undefined:
         throw ngraph_error("make_constant: Unsupported element type 'undefined'");
-    case element::Type_t::custom:
-        throw ngraph_error("make_constant: Unsupported element type 'custom'");
     }
 #if defined(__GNUC__) && !(__GNUC__ == 4 && __GNUC_MINOR__ == 8)
 #    pragma GCC diagnostic pop

--- a/src/core/include/openvino/core/descriptor/tensor.hpp
+++ b/src/core/include/openvino/core/descriptor/tensor.hpp
@@ -32,9 +32,7 @@ namespace descriptor {
 class OPENVINO_API Tensor {
 public:
     Tensor(const element::Type& element_type, const PartialShape& pshape, const std::string& name);
-    Tensor(const ov::Any& custom_element_type, const PartialShape& pshape, const std::string& name);
     Tensor(const element::Type& element_type, const PartialShape& pshape, Node* node, size_t node_output_number);
-    Tensor(const ov::Any& custom_element_type, const PartialShape& pshape, Node* node, size_t node_output_number);
 
     Tensor(const Tensor&) = delete;
     Tensor& operator=(const Tensor&) = delete;
@@ -51,11 +49,9 @@ public:
 
     OPENVINO_DEPRECATED("set_tensor_type() is deprecated. To change Tensor type please change the Parameter type")
     void set_tensor_type(const element::Type& element_type, const PartialShape& pshape);
-    void set_custom_tensor_type(ov::Any custom_element_type, const PartialShape& pshape);
     OPENVINO_DEPRECATED(
         "set_element_type() is deprecated. To change Tensor element type please change the Parameter type")
     void set_element_type(const element::Type& elemenet_type);
-    void set_custom_element_type(ov::Any custom_elemenet_type);
     OPENVINO_DEPRECATED(
         "set_partial_shape() is deprecated. To change Tensor partial shape please change the Parameter partial shape")
     void set_partial_shape(const PartialShape& partial_shape);
@@ -71,15 +67,6 @@ public:
 
     const element::Type& get_element_type() const {
         return m_element_type;
-    }
-    /// \brief Returns custom description of element type if element type is set to ov::element::custom
-    const ov::Any get_custom_element_type() const {
-        if (get_element_type() == ov::element::custom) {
-            return m_custom_element_type;
-        } else {
-            throw std::runtime_error("Attempt to query custom data type description for description::Tensor which "
-                                     "doesn't have a custom element type");
-        }
     }
     const Shape& get_shape() const;
     const PartialShape& get_partial_shape() const {
@@ -112,9 +99,6 @@ public:
 
 protected:
     element::Type m_element_type;
-
-    // TODO: Consider moving to m_rt_info with a well specified key value
-    ov::Any m_custom_element_type;
 
     // TODO: remove along with get_shape
     // Initially there was Shape m_shape only available to keep shape information.

--- a/src/core/include/openvino/core/node.hpp
+++ b/src/core/include/openvino/core/node.hpp
@@ -273,11 +273,6 @@ public:
 
     void set_output_type(size_t i, const element::Type& element_type, const PartialShape& pshape);
 
-    /// Set custom output type, usually it is not a tensor, so pshape is set as for a scalar by default
-    // TODO: prefer using set_output_type but it conflicts with original function apparently because ov::Any has too
-    // generic ctor
-    void set_custom_output_type(size_t i, ov::Any custom_element_type, const PartialShape& pshape = PartialShape());
-
     /// Sets the number of outputs
     void set_output_size(size_t output_size);
 

--- a/src/core/include/openvino/core/type/element_type.hpp
+++ b/src/core/include/openvino/core/type/element_type.hpp
@@ -51,8 +51,7 @@ enum class Type_t {
     u8,         //!< u8 element type
     u16,        //!< u16 element type
     u32,        //!< u32 element type
-    u64,        //!< u64 element type
-    custom      //!< Custom element type, specified separately (in a user-define way)
+    u64        //!< u64 element type
 };
 
 /// \brief Base class to define element type
@@ -63,7 +62,6 @@ public:
     Type(const Type&) = default;
     constexpr Type(const Type_t t) : m_type{t} {}
     Type(size_t bitwidth, bool is_real, bool is_signed, bool is_quantized, const std::string& cname);
-    // explicit Type(const Any& custom_type);
     Type& operator=(const Type&) = default;
     std::string c_type_string() const;
     size_t size() const;
@@ -119,7 +117,6 @@ public:
 
 private:
     Type_t m_type{Type_t::undefined};
-    // Any m_custom_type;
 };
 
 using TypeVector = std::vector<Type>;
@@ -178,9 +175,6 @@ constexpr Type u32(Type_t::u32);
 /// \brief u64 element type
 /// \ingroup ov_element_cpp_api
 constexpr Type u64(Type_t::u64);
-/// \brief custom element type to support arbitrary user-defined typing system
-/// \ingroup ov_element_cpp_api
-constexpr Type custom(Type_t::custom);
 
 template <typename T>
 Type from() {

--- a/src/core/include/openvino/core/type/element_type_traits.hpp
+++ b/src/core/include/openvino/core/type/element_type_traits.hpp
@@ -93,8 +93,4 @@ struct element_type_traits<element::Type_t::u64> {
     using value_type = uint64_t;
 };
 
-template <>
-struct element_type_traits<element::Type_t::custom> {
-    using value_type = ov::Any;
-};
 }  // namespace ov

--- a/src/core/include/openvino/op/constant.hpp
+++ b/src/core/include/openvino/op/constant.hpp
@@ -128,8 +128,6 @@ public:
         case Type_t::u64:
             fill_data<Type_t::u64>(value);
             break;
-        case Type_t::custom:
-            fill_data<Type_t::custom>(value);
         case Type_t::undefined:
         case Type_t::dynamic:
             throw std::runtime_error("unsupported type");
@@ -672,7 +670,6 @@ private:
             break;
         case element::Type_t::undefined:
         case element::Type_t::dynamic:
-        case element::Type_t::custom:
             throw std::runtime_error("unsupported type");
         }
 #if defined(__GNUC__) && !(__GNUC__ == 4 && __GNUC_MINOR__ == 8)

--- a/src/core/include/openvino/op/parameter.hpp
+++ b/src/core/include/openvino/op/parameter.hpp
@@ -28,8 +28,6 @@ public:
     /// \param pshape The partial shape of the parameter.
     Parameter(const ov::element::Type& element_type, const PartialShape& pshape);
 
-    Parameter(const ov::element::Type& element_type, const ov::Any& element_custom_type, const PartialShape& pshape);
-
     bool visit_attributes(AttributeVisitor& visitor) override;
 
     void validate_and_infer_types() override;
@@ -66,7 +64,6 @@ public:
 protected:
     PartialShape m_partial_shape;
     element::Type m_element_type;
-    Any m_element_custom_type;
     bool m_is_relevant_to_shapes{false};
 };
 }  // namespace v0

--- a/src/core/src/descriptor/tensor.cpp
+++ b/src/core/src/descriptor/tensor.cpp
@@ -12,16 +12,7 @@ ov::descriptor::Tensor::Tensor(const element::Type& element_type, const PartialS
     : m_element_type(element_type),
       m_partial_shape(pshape),
       m_name(name),
-      m_shape_changed(true) {
-    if(element_type == element::custom) {
-        throw std::runtime_error("Called Tensor::Tensor with custom element type, but custom element type was not provided. Use another constructor to pass custom element type.");
-    }
-}
-
-ov::descriptor::Tensor::Tensor(const ov::Any& custom_element_type, const PartialShape& pshape, const std::string& name)
-    : ov::descriptor::Tensor::Tensor(ov::element::custom, pshape, name) {
-    this->m_custom_element_type = custom_element_type;
-}
+      m_shape_changed(true) {}
 
 ov::descriptor::Tensor::Tensor(const ov::element::Type& element_type,
                                const PartialShape& pshape,
@@ -29,19 +20,7 @@ ov::descriptor::Tensor::Tensor(const ov::element::Type& element_type,
                                size_t node_output_number)
     : m_element_type(element_type),
       m_partial_shape(pshape),
-      m_shape_changed(true) {
-    if(element_type == element::custom) {
-        throw std::runtime_error("Called Tensor::Tensor with custom element type, but custom element type was not provided. Use another constructor to pass custom element type.");
-    }
-}
-
-ov::descriptor::Tensor::Tensor(const ov::Any& custom_element_type,
-                               const PartialShape& pshape,
-                               Node* node,
-                               size_t node_output_number)
-    : ov::descriptor::Tensor::Tensor(element::dynamic, pshape, node, node_output_number) {
-    set_custom_element_type(custom_element_type);
-}
+      m_shape_changed(true) {}
 
 OPENVINO_SUPPRESS_DEPRECATED_START
 void ov::descriptor::Tensor::set_tensor_type(const element::Type& element_type, const PartialShape& pshape) {
@@ -49,28 +28,8 @@ void ov::descriptor::Tensor::set_tensor_type(const element::Type& element_type, 
     set_partial_shape(pshape);
 }
 
-void ov::descriptor::Tensor::set_custom_tensor_type(ov::Any custom_element_type, const PartialShape& pshape) {
-    set_custom_element_type(custom_element_type);
-    set_partial_shape(pshape);
-}
-
 void ov::descriptor::Tensor::set_element_type(const element::Type& element_type) {
-    if (element_type == element::custom && m_custom_element_type.empty()) {
-        throw std::runtime_error("Called Tensor::set_element_type with custom, but custom element type is not initialized. Use set_custom_element_type.");
-    }
     m_element_type = element_type;
-}
-
-void ov::descriptor::Tensor::set_custom_element_type(ov::Any custom_element_type) {
-    // Check if custom_element_type is actually element::Type_t, in this case the type is regular, not a custom one
-    if (custom_element_type.is<element::Type>()) {
-        set_element_type(custom_element_type.as<element::Type>());
-    } else if (custom_element_type.empty()) {
-        throw std::runtime_error("Called Tensor::set_custom_element_type with uninitialized Any as an argument. This is prohibited.");
-    } else {
-        m_custom_element_type = custom_element_type;
-        set_element_type(element::custom);
-    }
 }
 
 void ov::descriptor::Tensor::set_partial_shape(const PartialShape& partial_shape) {

--- a/src/core/src/node.cpp
+++ b/src/core/src/node.cpp
@@ -261,12 +261,6 @@ void ov::Node::set_output_type(size_t i, const element::Type& element_type, cons
     OPENVINO_SUPPRESS_DEPRECATED_END
 }
 
-void ov::Node::set_custom_output_type(size_t i, ov::Any custom_element_type, const PartialShape& pshape) {
-    OPENVINO_SUPPRESS_DEPRECATED_START
-    get_output_descriptor(i).get_tensor_ptr()->set_custom_tensor_type(custom_element_type, pshape);
-    OPENVINO_SUPPRESS_DEPRECATED_END
-}
-
 std::string ov::Node::description() const {
     return get_type_name();
 }

--- a/src/core/src/op/constant.cpp
+++ b/src/core/src/op/constant.cpp
@@ -290,8 +290,6 @@ string ov::op::v0::Constant::convert_value_to_string(size_t index) const {
         throw runtime_error("unsupported type");
     case Type_t::dynamic:
         throw runtime_error("unsupported type");
-    case Type_t::custom:
-        throw runtime_error("Unsupported type 'custom' cannot be processed in Constant::convert_value_to_string");
     }
 #if defined(__GNUC__) && !(__GNUC__ == 4 && __GNUC_MINOR__ == 8)
 #    pragma GCC diagnostic pop
@@ -386,7 +384,6 @@ vector<string> ov::op::v0::Constant::get_value_strings() const {
         break;
     case element::Type_t::undefined:
     case element::Type_t::dynamic:
-    case element::Type_t::custom:
         throw runtime_error("unsupported type");
     }
 #if defined(__GNUC__) && !(__GNUC__ == 4 && __GNUC_MINOR__ == 8)
@@ -524,7 +521,6 @@ bool ov::op::v0::Constant::are_all_data_elements_bitwise_identical() const {
     case element::Type_t::u4:
     case element::Type_t::undefined:
     case element::Type_t::dynamic:
-    case element::Type_t::custom:
         break;
     }
 #if defined(__GNUC__) && !(__GNUC__ == 4 && __GNUC_MINOR__ == 8)

--- a/src/core/src/op/parameter.cpp
+++ b/src/core/src/op/parameter.cpp
@@ -22,25 +22,6 @@ op::Parameter::Parameter(const element::Type& element_type, const ov::PartialSha
     constructor_validate_and_infer_types();
 }
 
-op::Parameter::Parameter(const element::Type& element_type,
-                         const ov::Any& element_custom_type,
-                         const ov::PartialShape& pshape)
-    : m_partial_shape(pshape),
-      m_is_relevant_to_shapes(false) {
-    OPENVINO_ASSERT(element_type == element::custom,
-                    "Parameter ctor with 3 arguments accept element_type = element::custom only");
-    // If element_type is custom, it doesn't mean that it is really custom, it may be just a way to hide normal type
-    // under Any In some circumstances it is simpler to wrap a regular type in Any and then pass through multi-layer API
-    // that works with Any only
-    if (element_custom_type.is<element::Type>()) {
-        m_element_type = element_custom_type.as<element::Type>();
-    } else {
-        m_element_custom_type = element_custom_type;
-        m_element_type = element_type;  // custom
-    }
-    constructor_validate_and_infer_types();
-}
-
 bool op::Parameter::visit_attributes(AttributeVisitor& visitor) {
     OV_OP_SCOPE(v0_Parameter_visit_attributes);
     visitor.on_attribute("shape", m_partial_shape);
@@ -51,20 +32,13 @@ bool op::Parameter::visit_attributes(AttributeVisitor& visitor) {
 void op::Parameter::validate_and_infer_types() {
     OV_OP_SCOPE(v0_Parameter_validate_and_infer_types);
     Op::validate_and_infer_types();
-    if (m_element_type == element::custom) {
-        set_custom_output_type(0, m_element_custom_type, m_partial_shape);
-    } else {
-        set_output_type(0, m_element_type, m_partial_shape);
-    }
+    set_output_type(0, m_element_type, m_partial_shape);
 }
 
 shared_ptr<Node> op::Parameter::clone_with_new_inputs(const OutputVector& new_args) const {
     OV_OP_SCOPE(v0_Parameter_clone_with_new_inputs);
     check_new_args_count(this, new_args);
-    if(m_element_type == element::custom)
-        return make_shared<Parameter>(m_element_type, m_element_custom_type, m_partial_shape);
-    else
-        return make_shared<Parameter>(m_element_type, m_partial_shape);
+    return make_shared<Parameter>(m_element_type, m_partial_shape);
 }
 
 bool op::Parameter::is_relevant_to_shapes() const {

--- a/src/core/src/pass/serialize.cpp
+++ b/src/core/src/pass/serialize.cpp
@@ -631,8 +631,6 @@ std::string get_precision_name(const ngraph::element::Type& elem_type) {
         return "BIN";
     case ::ngraph::element::Type_t::boolean:
         return "BOOL";
-    case ::ngraph::element::Type_t::custom:
-        return "CUSTOM";
     default:
         std::stringstream msg;
         std::cerr << "[ ERROR ] Unsupported precision\n";

--- a/src/core/src/type/element_type.cpp
+++ b/src/core/src/type/element_type.cpp
@@ -73,9 +73,6 @@ inline TypeInfo get_type_info(ov::element::Type_t type) {
         return {32, false, false, false, "uint32_t", "u32"};
     case ov::element::Type_t::u64:
         return {64, false, false, false, "uint64_t", "u64"};
-    // This doesn't make sence for custom, but requird for various services
-    case ov::element::Type_t::custom:
-        return {0, false, false, false, "custom", "custom"};
     default:
         OPENVINO_UNREACHABLE("ov::element::Type_t not supported: ", type);
     }
@@ -99,8 +96,7 @@ std::vector<const ov::element::Type*> ov::element::Type::get_known_types() {
                                                 &ov::element::u8,
                                                 &ov::element::u16,
                                                 &ov::element::u32,
-                                                &ov::element::u64,
-                                                &ov::element::custom};
+                                                &ov::element::u64};
     return rc;
 }
 
@@ -365,8 +361,6 @@ inline size_t compiler_byte_size(ov::element::Type_t et) {
         return 0;
     case ov::element::Type_t::dynamic:
         return 0;
-    case ov::element::Type_t::custom:
-        return 0;
     }
 
     throw ov::Exception("compiler_byte_size: Unsupported value of ov::element::Type_t: " +
@@ -379,7 +373,6 @@ NGRAPH_API EnumNames<element::Type_t>& EnumNames<element::Type_t>::get() {
     static auto enum_names = EnumNames<element::Type_t>("element::Type_t",
                                                         {{"undefined", element::Type_t::undefined},
                                                          {"dynamic", element::Type_t::dynamic},
-                                                         {"custom", element::Type_t::custom},
                                                          {"boolean", element::Type_t::boolean},
                                                          {"bf16", element::Type_t::bf16},
                                                          {"f16", element::Type_t::f16},

--- a/src/core/src/validation_util.cpp
+++ b/src/core/src/validation_util.cpp
@@ -1171,8 +1171,7 @@ bool ngraph::could_propagate(const Output<Node>& output, std::vector<Node*>& ord
         auto current_node = nodes_to_calculate.front();
         nodes_to_calculate.pop_front();
 
-        if (current_node->inputs().empty() && !is_type<op::Constant>(current_node) ||
-                current_node->output(0).get_element_type() == ov::element::custom)
+        if (current_node->inputs().empty() && !is_type<op::Constant>(current_node))
             status = false;
         else if (!is_type<op::v0::ShapeOf>(current_node) && !is_type<op::v3::ShapeOf>(current_node)) {
             // not a leaf, not a shape_of -- continue to search

--- a/src/frontends/pytorch/include/openvino/frontend/pytorch/decoder.hpp
+++ b/src/frontends/pytorch/include/openvino/frontend/pytorch/decoder.hpp
@@ -31,6 +31,8 @@ struct List {
     Any element_type;
 };
 
+struct Str {};
+
 struct Optional;
 struct Dict;
 struct NamedTuple;

--- a/src/frontends/pytorch/src/pt_framework_node.hpp
+++ b/src/frontends/pytorch/src/pt_framework_node.hpp
@@ -53,7 +53,9 @@ public:
             // std::cout << "Can be represented as element::Type: " << type.is<element::Type>() << std::endl;
             // std::cout << "element::Type value: " << type.as<element::Type>() << "\n";
             // std::exit(0);
-            set_custom_output_type(i, type, ps);
+            
+            // TODO: Set custom `type` via special API
+            set_output_type(i, element::dynamic, ps);
         }
     }
 
@@ -127,11 +129,8 @@ public:
                         ov::as_type_ptr<op::v0::TensorIterator::BodyOutputDescription>(output_description)) {
                     const ov::PartialShape& ps = body_value.get_partial_shape();
                     auto et = body_value.get_element_type();
-                    if (et == element::custom) {
-                        output(index).get_tensor().set_custom_element_type(body_value.get_custom_element_type());
-                    } else {
-                        set_output_type(index, et, ps);
-                    }
+                    // TODO: Propagate custom type from body to the external in case if et is dynamic
+                    set_output_type(index, et, ps);
                 }
             }
         }

--- a/src/frontends/pytorch/src/transforms.cpp
+++ b/src/frontends/pytorch/src/transforms.cpp
@@ -21,7 +21,28 @@ using ov::pass::pattern::wrap_type;
 using std::make_shared;
 using std::shared_ptr;
 
+
+const Type::List* is_list (const descriptor::Tensor& tensor) {
+    if (tensor.get_element_type() == element::custom) {
+        auto custom_type = tensor.get_custom_element_type();
+        if(custom_type.is<Type::List>()) {
+            return &custom_type.as<Type::List>();
+        }
+    }
+
+    return nullptr;
+}
+
+
 std::tuple<bool, Any> is_list_of_tensors(const descriptor::Tensor& tensor) {
+    if (auto list = is_list(tensor)) {
+        if(list->element_type.is<Type::Tensor>()) {
+            return std::make_tuple(true, tensor.get_custom_element_type());  // UGLY: used custom type from the top again
+        }
+    }
+
+    return std::make_tuple(false, Any());
+
     if (tensor.get_element_type() != element::custom)
         return std::make_tuple(false, Any());
     Any custom_type = tensor.get_custom_element_type();
@@ -41,6 +62,7 @@ std::tuple<bool, Any> is_list_of_tensors(const descriptor::Tensor& tensor) {
 
     return std::make_tuple(true, custom_type);
 }
+
 
 std::shared_ptr<FrameworkNode> make_list_pack(const OutputVector& inputs, Any output_type, const PartialShape& shape) {
     auto list_pack = make_shared<FrameworkNode>(inputs, 1);  // 6 inputs -- 1 output
@@ -365,9 +387,11 @@ public:
     }
 };
 
+
+
 void apply_pytorch_conversion_transforms(std::shared_ptr<ov::Model> model) {
     // TODO: We have issues with List transformations, temporary disabled
-    return;
+    //return;
 
     pass::Manager manager;
     manager.register_pass<DecomposeListParameters>();

--- a/src/frontends/pytorch/src/transforms.cpp
+++ b/src/frontends/pytorch/src/transforms.cpp
@@ -23,19 +23,21 @@ using std::shared_ptr;
 
 
 const Type::List* is_list (const descriptor::Tensor& tensor) {
-    if (tensor.get_element_type() == element::custom) {
+    // TODO: Use special API to get custom type detalization
+    /*if (falsetensor.get_element_type() == element::custom) {
         auto custom_type = tensor.get_custom_element_type();
         if(custom_type.is<Type::List>()) {
             return &custom_type.as<Type::List>();
         }
-    }
+    }*/
 
     return nullptr;
 }
 
 
 std::tuple<bool, Any> is_list_of_tensors(const descriptor::Tensor& tensor) {
-    if (auto list = is_list(tensor)) {
+    // TODO: Use special API to get custom type detalization
+    /*if (auto list = is_list(tensor)) {
         if(list->element_type.is<Type::Tensor>()) {
             return std::make_tuple(true, tensor.get_custom_element_type());  // UGLY: used custom type from the top again
         }
@@ -45,7 +47,8 @@ std::tuple<bool, Any> is_list_of_tensors(const descriptor::Tensor& tensor) {
 
     if (tensor.get_element_type() != element::custom)
         return std::make_tuple(false, Any());
-    Any custom_type = tensor.get_custom_element_type();
+    Any custom_type = tensor.get_custom_element_type();*/
+    Any custom_type;
     if (custom_type.empty()) {
         return std::make_tuple(false, Any());
     }
@@ -69,7 +72,8 @@ std::shared_ptr<FrameworkNode> make_list_pack(const OutputVector& inputs, Any ou
     if(output_type.empty()) {
         throw std::runtime_error("Attemt to call make_list_pack with empty output_type");
     }
-    list_pack->set_custom_output_type(0, output_type, shape);
+    // TODO: Use special API to set custom type detalization
+    //list_pack->set_custom_output_type(0, output_type, shape);
     op::util::FrameworkNodeAttrs attrs;
     attrs.set_type_name("PTFE::ListPack");
     list_pack->set_attrs(attrs);
@@ -391,7 +395,7 @@ public:
 
 void apply_pytorch_conversion_transforms(std::shared_ptr<ov::Model> model) {
     // TODO: We have issues with List transformations, temporary disabled
-    //return;
+    return;
 
     pass::Manager manager;
     manager.register_pass<DecomposeListParameters>();

--- a/src/frontends/pytorch/src/utils.cpp
+++ b/src/frontends/pytorch/src/utils.cpp
@@ -231,7 +231,8 @@ std::shared_ptr<ov::Model> convert_pytorch_model(std::shared_ptr<Decoder> pytorc
         for (int i = 0; i < inputs.size(); ++i) {
             PartialShape ps = pytorch_model->get_input_shape(i);
             auto type = simplified_type_interpret(pytorch_model->get_input_type(i));
-            auto parameter = std::make_shared<opset8::Parameter>(ov::element::custom, type, ps);
+            // TODO: Use special API to set custom type detalization
+            auto parameter = std::make_shared<opset8::Parameter>(ov::element::dynamic, ps);
             parameter->get_output_tensor(0).add_names({std::to_string(pytorch_model->input(i))});
             parameters.push_back(parameter);
             auto order = pytorch_model->get_input_transpose_order(i);
@@ -266,7 +267,8 @@ std::shared_ptr<ov::Model> convert_pytorch_model(std::shared_ptr<Decoder> pytorc
                     // TODO: Eliminate duplication with the main code for Parameters creation
                     PartialShape ps = node->get_input_shape(i);
                     auto type = simplified_type_interpret(node->get_input_type(i));
-                    auto parameter = std::make_shared<opset8::Parameter>(element::custom, type, ps);
+                    // TODO: Use special API to set custom type detalization
+                    auto parameter = std::make_shared<opset8::Parameter>(element::dynamic, ps);
                     // TODO: Missing get_input_transpose_order handling for not trivial layouts
                     tensor_map[input] = parameter;
                     // set name of parameter to the index of node in the model

--- a/src/plugins/template/backend/pass/dyn_elimination.cpp
+++ b/src/plugins/template/backend/pass/dyn_elimination.cpp
@@ -110,7 +110,6 @@ void pass::DynElimination::construct_range() {
         case element::Type_t::undefined:
         case element::Type_t::dynamic:
         case element::Type_t::boolean:
-        case element::Type_t::custom:
             NGRAPH_CHECK(false, "Internal nGraph error: unsupported element type: ", et);
             break;
         }


### PR DESCRIPTION
Removed custom element types from core classes. Disabled list of tensor processing because there is no way to represent detailed custom type with this change.