### PR TITLE
support aten::_convolution for transposed case

### DIFF
--- a/src/frontends/pytorch/src/op/convolution.cpp
+++ b/src/frontends/pytorch/src/op/convolution.cpp
@@ -26,7 +26,7 @@ Output<ov::Node> reshape_bias(NodeContext& context, Output<ov::Node> bias, Outpu
 }
 
 OutputVector translate_convolution(NodeContext& context) {
-    // Shchema: aten::_convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[]
+    // Schema: aten::_convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[]
     // dilation, bool transposed, int[] output_padding, int groups, bool benchmark, bool deterministic, bool
     // cudnn_enabled, bool allow_tf32) -> Tensor
 

--- a/src/frontends/pytorch/src/op/convolution.cpp
+++ b/src/frontends/pytorch/src/op/convolution.cpp
@@ -11,42 +11,85 @@ namespace frontend {
 namespace pytorch {
 namespace op {
 
+Output<ov::Node> reshape_bias(NodeContext& context, Output<ov::Node> bias, Output<ngraph::Node> conv) {
+    auto conv_shape = context.mark_node(std::make_shared<opset8::ShapeOf>(conv));
+    auto conv_rank = context.mark_node(std::make_shared<opset8::ShapeOf>(conv_shape));
+    auto one_const = context.mark_node(opset8::Constant::create(element::i64, Shape{1}, {1}));
+    auto two_const = context.mark_node(opset8::Constant::create(element::i64, Shape{1}, {2}));
+    auto tail_shape_rank = context.mark_node(std::make_shared<opset8::Subtract>(conv_rank, two_const));
+    auto tail_shape = context.mark_node(std::make_shared<opset8::Broadcast>(one_const, tail_shape_rank));
+    auto channels_dim = context.mark_node(std::make_shared<opset8::ShapeOf>(bias));
+    auto new_shape =
+        context.mark_node(std::make_shared<opset8::Concat>(OutputVector{one_const, channels_dim, tail_shape}, 0));
+
+    return context.mark_node(std::make_shared<opset8::Reshape>(bias, new_shape, false));
+}
+
 OutputVector translate_convolution(NodeContext& context) {
     // Shchema: aten::_convolution(Tensor input, Tensor weight, Tensor? bias, int[] stride, int[] padding, int[]
     // dilation, bool transposed, int[] output_padding, int groups, bool benchmark, bool deterministic, bool
     // cudnn_enabled, bool allow_tf32) -> Tensor
-    bool transposed = context.const_input<bool>(6);
-    // TODO: Handle this temporary limitation
-    OV_FRONTEND_REQUIRE(!transposed);
 
     auto strides = context.const_input<Strides>(3);
-    auto pads_begin = context.const_input<CoordinateDiff>(4);  // FIXME: The same 4 is used twice
-    auto pads_end = context.const_input<CoordinateDiff>(4);    // FIXME: The same 4 is used twice
+    auto pads = context.const_input<CoordinateDiff>(4);
     auto dilations = context.const_input<Strides>(5);
-    // TODO: Handle skipped input 7 (6 was used above) -- what is it for?
+    bool transposed = context.const_input<bool>(6);
+    auto output_padding = context.const_input<CoordinateDiff>(7);
     auto groups = context.const_input<int64_t>(8);
 
     std::shared_ptr<ov::Node> conv;
     if (groups == 1) {
-        conv = std::make_shared<opset8::Convolution>(context.get_input(0),
-                                                     context.get_input(1),
-                                                     strides,
-                                                     pads_begin,
-                                                     pads_end,
-                                                     dilations);
+        if (!transposed) {
+            conv = context.mark_node(std::make_shared<opset8::Convolution>(context.get_input(0),
+                                                                           context.get_input(1),
+                                                                           strides,
+                                                                           pads,
+                                                                           pads,
+                                                                           dilations));
+        } else {
+            conv = context.mark_node(std::make_shared<opset8::ConvolutionBackpropData>(context.get_input(0),
+                                                                                       context.get_input(1),
+                                                                                       strides,
+                                                                                       pads,
+                                                                                       pads,
+                                                                                       dilations,
+                                                                                       ov::op::PadType::EXPLICIT,
+                                                                                       output_padding));
+        }
     } else {
-        conv = std::make_shared<opset8::GroupConvolution>(
-            context.get_input(0),
-            context.mark_output(reshape_kernel_for_group(context, context.get_input(0), context.get_input(1), groups)),
-            strides,
-            pads_begin,
-            pads_end,
-            dilations);
+        if (!transposed) {
+            conv = context.mark_node(std::make_shared<opset8::GroupConvolution>(
+                context.get_input(0),
+                context.mark_output(
+                    reshape_kernel_for_group(context, context.get_input(0), context.get_input(1), groups)),
+                strides,
+                pads,
+                pads,
+                dilations));
+        } else {
+            conv = context.mark_node(std::make_shared<opset8::GroupConvolutionBackpropData>(
+                context.get_input(0),
+                context.mark_output(
+                    reshape_kernel_for_group(context, context.get_input(0), context.get_input(1), groups)),
+                strides,
+                pads,
+                pads,
+                dilations,
+                ov::op::PadType::EXPLICIT,
+                output_padding));
+        }
+    }
+    if (!context.input_is_none(2)) {
+        auto bias = context.get_input(2);
+        auto bias_rank = bias.get_partial_shape().rank();
+        if (bias_rank == 1) {
+            bias = reshape_bias(context, bias, conv);
+        }
+
+        conv = context.mark_node(std::make_shared<opset8::Add>(conv, bias));
     }
 
-    // FIXME: Doesn't work for dynamic rank
-    // FIXME: Works for 2D convolutions only
-    return {context.mark_output(make_optional_bias(conv, context, 2, {-2, -1}))};
+    return {context.mark_output(conv)};
 };
 
 }  // namespace op

--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -65,7 +65,6 @@ OP_CONVERTER(translate_view);
 const std::map<std::string, CreatorFunction> get_supported_ops() {
     return {
         {"aten::_convolution", op::translate_convolution},
-        {"aten::convolution", op::translate_convolution},
         {"aten::abs", op::translate_1to1_match_1_inputs<opset8::Abs>},
         {"aten::adaptive_avg_pool2d", op::translate_1to1_match_2_inputs<opset8::AdaptiveAvgPool>},
         {"aten::adaptive_max_pool2d", op::translate_adaptive_max_pool2d},
@@ -79,6 +78,7 @@ const std::map<std::string, CreatorFunction> get_supported_ops() {
         {"aten::contiguous", op::skip_node},  // In openvino how tensors are stored in memory is internal plugin detail,
                                               // we assume all tensors are contiguous
         {"aten::conv2d", op::translate_conv2d},
+        {"aten::convolution", op::translate_convolution},
         {"aten::dim", op::translate_dim},
         {"aten::div", op::translate_div},
         {"aten::div_", op::inplace_op<op::translate_div>},

--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -65,6 +65,7 @@ OP_CONVERTER(translate_view);
 const std::map<std::string, CreatorFunction> get_supported_ops() {
     return {
         {"aten::_convolution", op::translate_convolution},
+        {"aten::convolution", op::translate_convolution},
         {"aten::abs", op::translate_1to1_match_1_inputs<opset8::Abs>},
         {"aten::adaptive_avg_pool2d", op::translate_1to1_match_2_inputs<opset8::AdaptiveAvgPool>},
         {"aten::adaptive_max_pool2d", op::translate_adaptive_max_pool2d},

--- a/tests/layer_tests/pytorch_tests/test_convolution.py
+++ b/tests/layer_tests/pytorch_tests/test_convolution.py
@@ -1,0 +1,221 @@
+# Copyright (C) 2018-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from pytorch_layer_test_class import PytorchLayerTest
+
+
+d2_params = [{'weights_shape': [3, 3, 2, 2], 'strides': [1, 1], 'pads': [0, 0], 'dilations': [1, 1], 'groups': 1, 'output_padding': [0, 0], 'transposed': True},
+             {'weights_shape': [3, 3, 2, 2], 'strides': [1, 1], 'pads': [0, 0], 'dilations': [
+                 1, 1], 'groups': 1, 'output_padding': [0, 0], 'transposed': False},
+             {'weights_shape': [3, 1, 1, 1], 'strides': [1, 1], 'pads': [0, 0], 'dilations': [
+                 1, 1], 'groups': 3, 'output_padding': [0, 0], 'transposed': True},
+             {'weights_shape': [3, 1, 1, 1], 'strides': [1, 1], 'pads': [0, 0], 'dilations': [
+                 1, 1], 'groups': 3, 'output_padding': [0, 0], 'transposed': False},
+             {'weights_shape': [3, 1, 1, 1], 'strides': [1, 1], 'bias_shape': [1], 'pads': [
+                 1, 1], 'dilations': [1, 1], 'groups': 1, 'output_padding': [0, 0], 'transposed': True},
+             {'weights_shape': [3, 3, 1, 1], 'strides': [1, 1], 'pads': [
+                 1, 1], 'dilations': [1, 1], 'groups': 1, 'output_padding': [0, 0], 'transposed': False},
+             {'weights_shape': [3, 1, 1, 1], 'strides': [1, 1], 'bias_shape': [1], 'pads': [
+                 3, 1], 'dilations': [1, 1], 'groups': 1, 'output_padding': [0, 0], 'transposed': True},
+             {'weights_shape': [3, 3, 1, 1], 'strides': [1, 1], 'pads': [
+                 3, 1], 'dilations': [1, 1], 'groups': 1, 'output_padding': [0, 0], 'transposed': False},
+             {'weights_shape': [3, 1, 1, 1], 'strides': [1, 1], 'bias_shape': [1], 'pads': [
+                 1, 0], 'dilations': [1, 1], 'groups': 1, 'output_padding': [0, 0], 'transposed': True},
+             {'weights_shape': [3, 3, 1, 1], 'strides': [1, 1], 'pads': [
+                 0, 1], 'dilations': [1, 1], 'groups': 1, 'output_padding': [0, 0], 'transposed': False},
+             {'weights_shape': [3, 1, 1, 1], 'strides': [1, 1], 'pads': [
+                 1, 0], 'dilations': [1, 1], 'groups': 3, 'output_padding': [0, 0], 'transposed': True},
+             {'weights_shape': [3, 1, 1, 1], 'strides': [1, 1], 'pads': [
+                 0, 1], 'dilations': [1, 1], 'groups': 3, 'output_padding': [0, 0], 'transposed': False},
+             {'weights_shape': [3, 1, 1, 1], 'strides': [1, 1], 'pads': [
+                 1, 0], 'dilations': [2, 2], 'groups': 3, 'output_padding': [0, 0], 'transposed': True},
+             {'weights_shape': [3, 1, 1, 1], 'strides': [1, 1], 'pads': [
+                 0, 0], 'dilations': [2, 2], 'groups': 3, 'output_padding': [0, 0], 'transposed': False},
+             {'weights_shape': [3, 1, 1, 1], 'strides': [2, 1], 'bias_shape': [1], 'pads': [
+                 1, 0], 'dilations': [1, 1], 'groups': 1, 'output_padding': [0, 0], 'transposed': True},
+             {'weights_shape': [3, 3, 1, 1], 'strides': [2, 1], 'pads': [
+                 0, 0], 'dilations': [1, 1], 'groups': 1, 'output_padding': [0, 0], 'transposed': False},
+             {'weights_shape': [3, 1, 1, 1], 'strides': [2, 2], 'bias_shape': [1], 'pads': [
+                 0, 0], 'dilations': [1, 1], 'groups': 1, 'output_padding': [0, 0], 'transposed': True},
+             {'weights_shape': [3, 3, 1, 1], 'strides': [2, 2], 'pads': [
+                 0, 0], 'dilations': [1, 1], 'groups': 1, 'output_padding': [0, 0], 'transposed': False},
+             {'weights_shape': [3, 3, 1, 1], 'strides': [2, 1], 'pads': [
+                 0, 0], 'dilations': [1, 1], 'groups': 1, 'output_padding': [0, 0], 'transposed': False},
+             {'weights_shape': [3, 1, 1, 1], 'strides': [2, 2], 'bias_shape': [1], 'pads': [
+                 0, 0], 'dilations': [1, 1], 'groups': 1, 'output_padding': [0, 0], 'transposed': True},
+             {'weights_shape': [3, 1, 1, 1], 'strides': [2, 2], 'bias_shape': [1], 'pads': [
+                 1, 1], 'dilations': [2, 2], 'groups': 1, 'output_padding': [1, 1], 'transposed': True},
+             ]
+
+d1_params = [{'weights_shape': [3, 3, 2], 'strides': [1], 'pads': [0], 'dilations': [1], 'groups': 1, 'output_padding': [0], 'transposed': True},
+             {'weights_shape': [3, 3, 2], 'strides': [1], 'pads': [0], 'dilations': [
+                 1], 'groups': 1, 'output_padding': [0], 'transposed': False},
+             {'weights_shape': [3, 1, 1], 'strides': [1], 'pads': [0], 'dilations': [
+                 1], 'groups': 3, 'output_padding': [0], 'transposed': True},
+             {'weights_shape': [3, 1, 1], 'strides': [1], 'pads': [0], 'dilations': [
+                 1], 'groups': 3, 'output_padding': [0], 'transposed': False},
+             {'weights_shape': [3, 1, 1], 'strides': [1], 'bias_shape': [1], 'pads': [
+                 1], 'dilations': [1], 'groups': 1, 'output_padding': [0], 'transposed': True},
+             {'weights_shape': [3, 3, 1], 'strides': [1], 'pads': [
+                 1], 'dilations': [1], 'groups': 1, 'output_padding': [0], 'transposed': False},
+             {'weights_shape': [3, 1, 1], 'strides': [1], 'bias_shape': [1], 'pads': [
+                 3], 'dilations': [1], 'groups': 1, 'output_padding': [0], 'transposed': True},
+             {'weights_shape': [3, 3, 1], 'strides': [1], 'pads': [
+                 3], 'dilations': [1], 'groups': 1, 'output_padding': [0], 'transposed': False},
+             {'weights_shape': [3, 1, 1], 'strides': [1], 'bias_shape': [1], 'pads': [
+                 1], 'dilations': [1], 'groups': 1, 'output_padding': [0], 'transposed': True},
+             {'weights_shape': [3, 3, 1], 'strides': [1], 'pads': [
+                 0], 'dilations': [1], 'groups': 1, 'output_padding': [0], 'transposed': False},
+             {'weights_shape': [3, 1, 1], 'strides': [1], 'pads': [
+                 1], 'dilations': [1], 'groups': 3, 'output_padding': [0], 'transposed': True},
+             {'weights_shape': [3, 1, 1], 'strides': [1], 'pads': [1], 'dilations': [
+                 1], 'groups': 3, 'output_padding': [0], 'transposed': False},
+             {'weights_shape': [3, 1, 1], 'strides': [1], 'pads': [
+                 1], 'dilations': [2], 'groups': 3, 'output_padding': [0], 'transposed': True},
+             {'weights_shape': [3, 1, 1], 'strides': [1], 'pads': [
+                 0], 'dilations': [2], 'groups': 3, 'output_padding': [0], 'transposed': False},
+             {'weights_shape': [3, 1, 1], 'strides': [2], 'bias_shape': [1], 'pads': [
+                 1], 'dilations': [1], 'groups': 1, 'output_padding': [0], 'transposed': True},
+             {'weights_shape': [3, 3, 1], 'strides': [2], 'pads': [
+                 0], 'dilations': [1], 'groups': 1, 'output_padding': [0], 'transposed': False},
+             {'weights_shape': [3, 1, 1], 'strides': [2], 'bias_shape': [1], 'pads': [
+                 0], 'dilations': [1], 'groups': 1, 'output_padding': [0], 'transposed': True},
+             {'weights_shape': [3, 3, 1], 'strides': [2], 'pads': [
+                 0], 'dilations': [1], 'groups': 1, 'output_padding': [0], 'transposed': False},
+             {'weights_shape': [3, 3, 1], 'strides': [1], 'pads': [0], 'dilations': [
+                 1], 'groups': 1, 'output_padding': [0], 'transposed': False},
+             {'weights_shape': [3, 1, 1], 'strides': [2], 'bias_shape': [1], 'pads': [
+                 0], 'dilations': [1], 'groups': 1, 'output_padding': [0], 'transposed': True},
+             {'weights_shape': [3, 1, 1], 'strides': [2], 'bias_shape': [1], 'pads': [
+                 1], 'dilations': [2], 'groups': 1, 'output_padding': [1], 'transposed': True},
+             ]
+
+d3_params = [{'weights_shape': [3, 3, 2, 2, 1], 'strides': [1, 1, 1], 'pads': [0, 0, 0], 'dilations': [1, 1, 1], 'groups': 1, 'output_padding': [0, 0, 0], 'transposed': True},
+             {'weights_shape': [3, 3, 2, 2, 1], 'strides': [1, 1, 1], 'pads': [0, 0, 0], 'dilations': [
+                 1, 1, 1], 'groups': 1, 'output_padding': [0, 0], 'transposed': False},
+             {'weights_shape': [3, 1, 1, 1, 1], 'strides': [1, 1, 1], 'pads': [0, 0, 0], 'dilations': [
+                 1, 1, 1], 'groups': 3, 'output_padding': [0, 0, 0], 'transposed': True},
+             {'weights_shape': [3, 1, 1, 1, 1], 'strides': [1, 1, 1], 'pads': [0, 0, 0], 'dilations': [
+                 1, 1, 1], 'groups': 3, 'output_padding': [0, 0], 'transposed': False},
+             {'weights_shape': [3, 1, 1, 1, 1], 'strides': [1, 1, 1], 'bias_shape': [1], 'pads': [
+                 1, 1, 1], 'dilations': [1, 1, 1], 'groups': 1, 'output_padding': [0, 0, 0], 'transposed': True},
+             {'weights_shape': [3, 3, 1, 1, 1], 'strides': [1, 1, 1], 'pads': [
+                 1, 1, 1], 'dilations': [1, 1, 1], 'groups': 1, 'output_padding': [0, 0, 0], 'transposed': False},
+             {'weights_shape': [3, 1, 1, 1, 1], 'strides': [1, 1, 1], 'bias_shape': [1], 'pads': [
+                 3, 1, 3], 'dilations': [1, 1, 1], 'groups': 1, 'output_padding': [0, 0, 0], 'transposed': True},
+             {'weights_shape': [3, 3, 1, 1, 1], 'strides': [1, 1, 1], 'pads': [
+                 3, 1, 3], 'dilations': [1, 1, 1], 'groups': 1, 'output_padding': [0, 0, 0], 'transposed': False},
+             {'weights_shape': [3, 1, 1, 1, 1], 'strides': [1, 1, 1], 'bias_shape': [1], 'pads': [
+                 1, 0, 0], 'dilations': [1, 1, 1], 'groups': 1, 'output_padding': [0, 0, 0], 'transposed': True},
+             {'weights_shape': [3, 3, 1, 1, 1], 'strides': [1, 1, 1], 'pads': [
+                 0, 1, 0], 'dilations': [1, 1, 1], 'groups': 1, 'output_padding': [0, 0, 0], 'transposed': False},
+             {'weights_shape': [3, 1, 1, 1, 1], 'strides': [1, 1, 1], 'pads': [
+                 1, 0, 0], 'dilations': [1, 1, 1], 'groups': 3, 'output_padding': [0, 0, 0], 'transposed': True},
+             {'weights_shape': [3, 1, 1, 1, 1], 'strides': [1, 1, 1], 'pads': [
+                 0, 1, 1], 'dilations': [1, 1, 1], 'groups': 3, 'output_padding': [0, 0, 0], 'transposed': False},
+             {'weights_shape': [3, 1, 1, 1, 1], 'strides': [1, 1, 1], 'pads': [
+                 1, 0, 0], 'dilations': [2, 2, 1], 'groups': 3, 'output_padding': [0, 0, 0], 'transposed': True},
+             {'weights_shape': [3, 1, 1, 1, 1], 'strides': [1, 1, 1], 'pads': [
+                 0, 0, 0], 'dilations': [2, 2, 2], 'groups': 3, 'output_padding': [0, 0, 0], 'transposed': False},
+             {'weights_shape': [3, 1, 1, 1, 1], 'strides': [2, 1, 1], 'bias_shape': [1], 'pads': [
+                 1, 0, 0], 'dilations': [1, 1, 1], 'groups': 1, 'output_padding': [0, 0, 0], 'transposed': True},
+             {'weights_shape': [3, 3, 1, 1, 1], 'strides': [2, 1, 1], 'pads': [
+                 0, 0, 0], 'dilations': [1, 1, 1], 'groups': 1, 'output_padding': [0, 0, 0], 'transposed': False},
+             {'weights_shape': [3, 1, 1, 1, 1], 'strides': [2, 2, 2], 'bias_shape': [1], 'pads': [
+                 0, 0, 0], 'dilations': [1, 1, 1], 'groups': 1, 'output_padding': [0, 0, 0], 'transposed': True},
+             {'weights_shape': [3, 3, 1, 1, 1], 'strides': [2, 2, 2], 'pads': [
+                 0, 0, 0], 'dilations': [1, 1, 1], 'groups': 1, 'output_padding': [0, 0, 0], 'transposed': False},
+             {'weights_shape': [3, 3, 1, 1, 1], 'strides': [2, 1, 1], 'pads': [
+                 0, 0, 1], 'dilations': [1, 1, 1], 'groups': 1, 'output_padding': [0, 0, 0], 'transposed': False},
+             {'weights_shape': [3, 1, 1, 1, 1], 'strides': [2, 2, 2], 'bias_shape': [1], 'pads': [
+                 0, 0, 0], 'dilations': [1, 1, 1], 'groups': 1, 'output_padding': [0, 0, 0], 'transposed': True},
+             {'weights_shape': [3, 1, 1, 1, 1], 'strides': [2, 2, 2], 'bias_shape': [1], 'pads': [
+                 1, 1, 1], 'dilations': [2, 2, 2], 'groups': 1, 'output_padding': [1, 1, 1], 'transposed': True},
+             ]
+
+
+class TestConvolution(PytorchLayerTest):
+    def _prepare_input(self, ndim=4):
+        import numpy as np
+        shape = (1, 3, 10, 10, 10)
+        return (np.random.randn(*shape[:ndim]).astype(np.float32),)
+
+    def create_model(self, weights_shape, strides, pads, dilations, groups, bias, transposed, output_padding=0, bias_shape=None, underscore=True):
+
+        import torch
+
+        bias_dim = 0
+
+        class aten__convolution(torch.nn.Module):
+            def __init__(self):
+                super(aten__convolution, self).__init__()
+                self.weight = torch.randn(weights_shape)
+                self.bias_shape = bias_shape
+                if self.bias_shape is None:
+                    self.bias_shape = weights_shape[bias_dim]
+                self.bias = torch.randn(self.bias_shape) if bias else None
+                self.strides = strides
+                self.pads = pads
+                self.dilations = dilations
+                self.groups = groups
+                self.transposed = transposed
+                self.output_padding = output_padding
+                self._op = torch._convolution
+                self._underscore = underscore
+
+            def forward(self, x):
+                return self._op(
+                    x, self.weight, self.bias, self.strides, self.pads, self.dilations, self.transposed, self.output_padding, self.groups, False, False, False, False
+                )
+
+        class aten_convolution(torch.nn.Module):
+            def __init__(self):
+                super(aten_convolution, self).__init__()
+                self.weight = torch.randn(weights_shape)
+                self.bias_shape = bias_shape
+                if self.bias_shape is None:
+                    self.bias_shape = weights_shape[bias_dim]
+                self.bias = torch.randn(self.bias_shape) if bias else None
+                self.strides = strides
+                self.pads = pads
+                self.dilations = dilations
+                self.groups = groups
+                self.transposed = transposed
+                self.output_padding = output_padding
+                self._op = torch.convolution
+                self._underscore = underscore
+
+            def forward(self, x):
+                return self._op(
+                    x, self.weight, self.bias, self.strides, self.pads, self.dilations, self.transposed, self.output_padding, self.groups
+                )
+
+        ref_net = None
+        if underscore:
+            return aten__convolution(), ref_net, "aten::_convolution"
+        return aten_convolution(), ref_net, "aten::convolution"
+
+    @ pytest.mark.parametrize("params", d2_params)
+    @pytest.mark.parametrize("bias", [True, False])
+    @pytest.mark.parametrize("underscore", [True, False])
+    @pytest.mark.nightly
+    def test_convolution2d(self, params, bias, underscore, ie_device, precision, ir_version):
+        self._test(*self.create_model(**params, bias=bias, underscore=underscore),
+                   ie_device, precision, ir_version, dynamic_shapes=params['groups'] == 1)
+
+    @pytest.mark.parametrize("params", d1_params)
+    @pytest.mark.parametrize("bias", [True, False])
+    @pytest.mark.parametrize("underscore", [True, False])
+    @pytest.mark.nightly
+    def test_convolution1d(self, params, bias, underscore, ie_device, precision, ir_version):
+        self._test(*self.create_model(**params, bias=bias, underscore=underscore),
+                   ie_device, precision, ir_version, dynamic_shapes=params['groups'] == 1, kwargs_to_prepare_input={'ndim': 3})
+
+    @pytest.mark.parametrize("params", d3_params)
+    @pytest.mark.parametrize("bias", [True, False])
+    @pytest.mark.parametrize("underscore", [True, False])
+    @pytest.mark.nightly
+    def test_convolution3d(self, params, bias, underscore, ie_device, precision, ir_version):
+        self._test(*self.create_model(**params, bias=bias, underscore=underscore),
+                   ie_device, precision, ir_version, dynamic_shapes=params['groups'] == 1, kwargs_to_prepare_input={'ndim': 5})

--- a/tests/layer_tests/pytorch_tests/test_convolution.py
+++ b/tests/layer_tests/pytorch_tests/test_convolution.py
@@ -162,8 +162,6 @@ class TestConvolution(PytorchLayerTest):
                 self.transposed = transposed
                 self.output_padding = output_padding
                 self._op = torch._convolution
-                self._underscore = underscore
-
             def forward(self, x):
                 return self._op(
                     x, self.weight, self.bias, self.strides, self.pads, self.dilations, self.transposed, self.output_padding, self.groups, False, False, False, False
@@ -184,7 +182,6 @@ class TestConvolution(PytorchLayerTest):
                 self.transposed = transposed
                 self.output_padding = output_padding
                 self._op = torch.convolution
-                self._underscore = underscore
 
             def forward(self, x):
                 return self._op(


### PR DESCRIPTION
aten::convolution is different version  of operator, which has less special parameters (use_cudnn, benchmark e.t.c.), which anyway do not used on our side, so it will have the same realization on our side 