### PR TITLE
Add transformations for aten::split+aten::__getitem__ and aten::split+prim::ListUnpack

### DIFF
--- a/src/frontends/pytorch/src/frontend.cpp
+++ b/src/frontends/pytorch/src/frontend.cpp
@@ -21,6 +21,7 @@
 #include "transformations/control_flow/unroll_if.hpp"
 #include "transforms.hpp"
 #include "transforms/aten_cat_replacer.hpp"
+#include "transforms/aten_getitem_replacer.hpp"
 #include "transforms/prim_list_unpack_replacer.hpp"
 #include "utils.hpp"
 
@@ -102,6 +103,7 @@ void FrontEnd::normalize(const std::shared_ptr<ov::Model>& model) const {
 
     manager.register_pass<ov::frontend::pytorch::pass::AtenCatToConcat>();
     manager.register_pass<ov::frontend::pytorch::pass::PrimListUnpackReplacer>();
+    manager.register_pass<ov::frontend::pytorch::pass::AtenGetItemReplacer>();
     manager.register_pass<ngraph::pass::UnrollIf>();  // TODO: remove
     manager.register_pass<ngraph::pass::ConstantFolding>();
 

--- a/src/frontends/pytorch/src/transforms/aten_getitem_replacer.cpp
+++ b/src/frontends/pytorch/src/transforms/aten_getitem_replacer.cpp
@@ -32,10 +32,11 @@ AtenGetItemReplacer::AtenGetItemReplacer() {
 
         auto input_node = getitem->input_value(0).get_node_shared_ptr();
         if (auto torch_split = cast_fw_node(input_node, "aten::split")) {
-            if (torch_split->input(1).get_partial_shape().is_dynamic()) {
+            auto rank = torch_split->input(1).get_partial_shape().rank();
+            if (rank.is_dynamic()) {
                 return false;
             }
-            if ((torch_split->get_input_source_output(1).get_shape()) == Shape{}) {
+            if (rank.get_length() == 0) {
                 // Based on slice_size and output index select size.
                 // Constants required by transformation.
                 auto const_1 = opset8::Constant::create(element::i64, Shape{1}, {1});

--- a/src/frontends/pytorch/src/transforms/aten_getitem_replacer.cpp
+++ b/src/frontends/pytorch/src/transforms/aten_getitem_replacer.cpp
@@ -26,11 +26,11 @@ AtenGetItemReplacer::AtenGetItemReplacer() {
         auto getitem = cast_fw_node(m.get_match_root(), "aten::__getitem__");
         if (!getitem)
             return false;
-        auto getitem_index_ptr = getitem->input(1).get_source_output().get_node_shared_ptr();
+        auto getitem_index_ptr = getitem->input_value(1).get_node_shared_ptr();
         auto getitem_index_const = std::dynamic_pointer_cast<opset8::Constant>(getitem_index_ptr);
         auto index_val = getitem_index_const->cast_vector<int64_t>();
 
-        auto input_node = getitem->input(0).get_source_output().get_node_shared_ptr();
+        auto input_node = getitem->input_value(0).get_node_shared_ptr();
         if (auto torch_split = cast_fw_node(input_node, "aten::split")) {
             if ((torch_split->get_input_source_output(1).get_shape()) == Shape{}) {
                 // Based on slice_size and output index select size.

--- a/src/frontends/pytorch/src/transforms/aten_getitem_replacer.cpp
+++ b/src/frontends/pytorch/src/transforms/aten_getitem_replacer.cpp
@@ -1,0 +1,104 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "aten_getitem_replacer.hpp"
+
+#include <memory>
+#include <utility>
+
+#include "openvino/frontend/pytorch/visibility.hpp"
+#include "openvino/op/util/framework_node.hpp"
+#include "openvino/pass/pattern/matcher.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "pt_framework_node.hpp"
+#include "utils.hpp"
+
+namespace ov {
+namespace frontend {
+namespace pytorch {
+namespace pass {
+
+AtenGetItemReplacer::AtenGetItemReplacer() {
+    auto getitem = ov::pass::pattern::wrap_type<ov::op::util::FrameworkNode>();
+
+    ov::matcher_pass_callback callback = [](ov::pass::pattern::Matcher& m) {
+        auto getitem = cast_fw_node(m.get_match_root(), "aten::__getitem__");
+        if (!getitem)
+            return false;
+        auto getitem_index_ptr = getitem->input(1).get_source_output().get_node_shared_ptr();
+        auto getitem_index_const = std::dynamic_pointer_cast<opset8::Constant>(getitem_index_ptr);
+        auto index_val = getitem_index_const->cast_vector<int64_t>();
+
+        auto input_node = getitem->input(0).get_source_output().get_node_shared_ptr();
+        if (auto torch_split = cast_fw_node(input_node, "aten::split")) {
+            if ((torch_split->get_input_source_output(1).get_shape()) == Shape{}) {
+                // Based on slice_size and output index select size.
+                // Constants required by transformation.
+                auto const_1 = opset8::Constant::create(element::i64, Shape{1}, {1});
+                auto const_1_0d = opset8::Constant::create(element::i64, Shape{}, {1});
+                auto const_0 = opset8::Constant::create(element::i64, Shape{1}, {0});
+                auto const_0_0d = opset8::Constant::create(element::i64, Shape{}, {0});
+
+                // Load and convert op inputs.
+                auto input = torch_split->get_input_source_output(0);
+                auto split_size = torch_split->get_input_source_output(1);
+                auto split_size_1d = std::make_shared<opset8::Unsqueeze>(split_size, const_0);
+                auto axis = torch_split->get_input_source_output(2);
+                auto axis_1d = std::make_shared<opset8::Unsqueeze>(axis, const_0);
+                auto getitem_idx = getitem->input(1).get_source_output();
+
+                // Calculate number of splits based on input shape ant split_size.
+                auto shape = std::make_shared<opset8::ShapeOf>(input);
+                auto len_to_split = std::make_shared<opset8::Gather>(shape, axis, const_0);
+                // Convert to f64 from int to calculate reminder - last chunk can be smaller if Shape in given axis is
+                // not equally divisible.
+                auto len_to_split_float = std::make_shared<opset8::Convert>(len_to_split, element::f64);
+                auto split_size_1d_float = std::make_shared<opset8::Convert>(split_size_1d, element::f64);
+                auto out_div = std::make_shared<opset8::Divide>(len_to_split_float, split_size_1d_float);
+                auto out_num = std::make_shared<opset8::Ceiling>(out_div);
+                auto out_num_0d = std::make_shared<opset8::Squeeze>(out_num, const_0);
+
+                // Use Range and Gather to convert negative getitem indexes into positive due problems with indexing
+                // with -1.
+                auto possible_out_idx =
+                    std::make_shared<opset8::Range>(const_0_0d, out_num_0d, const_1_0d, split_size.get_element_type());
+                auto always_positive_out_idx = std::make_shared<opset8::Gather>(possible_out_idx, getitem_idx, const_0);
+
+                // Use Slice to get only split output selected by getitem idx. Couldn't use VariadicSplit due to
+                // problems with dynamic inputs.
+                auto split_slice_start = std::make_shared<opset8::Multiply>(always_positive_out_idx, split_size_1d);
+                auto split_slice_end = std::make_shared<opset8::Add>(split_slice_start, split_size_1d);
+                auto split =
+                    std::make_shared<opset8::Slice>(input, split_slice_start, split_slice_end, const_1, axis_1d);
+                copy_runtime_info({getitem, input_node}, split);
+                replace_node(getitem, split);
+            } else {
+                auto split = std::make_shared<opset8::VariadicSplit>(torch_split->get_input_source_output(0),
+                                                                     torch_split->get_input_source_output(2),
+                                                                     torch_split->get_input_source_output(1));
+                OutputVector res;
+                auto index = 0;
+                if (index_val[0] >= 0) {
+                    index = index_val[0];
+                } else {
+                    index = split->outputs().size() + index_val[0];
+                }
+                res.push_back(split->outputs()[index]);
+                copy_runtime_info({getitem, input_node}, split);
+                replace_node(getitem, res);
+            }
+            return true;
+        }
+
+        return false;
+    };
+
+    auto m = std::make_shared<ov::pass::pattern::Matcher>(getitem, "ov::frontend::pytorch::pass::AtenGetItemReplacer");
+    this->register_matcher(m, callback);
+};
+
+}  // namespace pass
+}  // namespace pytorch
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/pytorch/src/transforms/aten_getitem_replacer.cpp
+++ b/src/frontends/pytorch/src/transforms/aten_getitem_replacer.cpp
@@ -48,7 +48,7 @@ AtenGetItemReplacer::AtenGetItemReplacer() {
                 auto axis_1d = std::make_shared<opset8::Unsqueeze>(axis, const_0);
                 auto getitem_idx = getitem->input(1).get_source_output();
 
-                // Calculate number of splits based on input shape ant split_size.
+                // Calculate number of splits based on input shape and split_size.
                 auto shape = std::make_shared<opset8::ShapeOf>(input);
                 auto len_to_split = std::make_shared<opset8::Gather>(shape, axis, const_0);
                 // Convert to f64 from int to calculate reminder - last chunk can be smaller if Shape in given axis is

--- a/src/frontends/pytorch/src/transforms/aten_getitem_replacer.hpp
+++ b/src/frontends/pytorch/src/transforms/aten_getitem_replacer.hpp
@@ -1,0 +1,25 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/frontend/pytorch/visibility.hpp"
+#include "openvino/pass/graph_rewrite.hpp"
+#include "openvino/pass/pass.hpp"
+
+namespace ov {
+namespace frontend {
+namespace pytorch {
+namespace pass {
+
+class PYTORCH_API AtenGetItemReplacer : public ov::pass::MatcherPass {
+public:
+    OPENVINO_RTTI("ov::frontend::pytorch::pass::AtenGetItemReplacer");
+    AtenGetItemReplacer();
+};
+
+}  // namespace pass
+}  // namespace pytorch
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/pytorch/src/transforms/prim_list_unpack_replacer.cpp
+++ b/src/frontends/pytorch/src/transforms/prim_list_unpack_replacer.cpp
@@ -30,7 +30,7 @@ PrimListUnpackReplacer::PrimListUnpackReplacer() {
         if (auto torch_split = cast_fw_node(input_node, "aten::split")) {
             if (torch_split->get_input_source_output(1).get_shape() == Shape{}) {
                 // Create split_lenghts tensor from split_size int,
-                // allow for last chunk to be smaller if data cannot equally divisible.
+                // allow for last chunk to be smaller if data is not equally divisible.
                 auto split_size = torch_split->get_input_source_output(1);
                 // Using number of ListUnpack outputs.
                 auto num_out_m_1 = opset8::Constant::create(split_size.get_element_type(),

--- a/src/frontends/pytorch/src/transforms/prim_list_unpack_replacer.cpp
+++ b/src/frontends/pytorch/src/transforms/prim_list_unpack_replacer.cpp
@@ -26,7 +26,7 @@ PrimListUnpackReplacer::PrimListUnpackReplacer() {
         if (!list_unpack)
             return false;
 
-        auto input_node = list_unpack->input(0).get_source_output().get_node_shared_ptr();
+        auto input_node = list_unpack->input_value(0).get_node_shared_ptr();
         if (auto torch_split = cast_fw_node(input_node, "aten::split")) {
             if (torch_split->input(1).get_partial_shape().is_dynamic()) {
                 return false;

--- a/src/frontends/pytorch/src/transforms/prim_list_unpack_replacer.cpp
+++ b/src/frontends/pytorch/src/transforms/prim_list_unpack_replacer.cpp
@@ -28,10 +28,11 @@ PrimListUnpackReplacer::PrimListUnpackReplacer() {
 
         auto input_node = list_unpack->input_value(0).get_node_shared_ptr();
         if (auto torch_split = cast_fw_node(input_node, "aten::split")) {
-            if (torch_split->input(1).get_partial_shape().is_dynamic()) {
+            auto rank = torch_split->input(1).get_partial_shape().rank();
+            if (rank.is_dynamic()) {
                 return false;
             }
-            if (torch_split->get_input_source_output(1).get_shape() == Shape{}) {
+            if (rank.get_length() == 0) {
                 // Create split_lenghts tensor from split_size int,
                 // allow for last chunk to be smaller if data is not equally divisible.
                 auto split_size = torch_split->get_input_source_output(1);

--- a/src/frontends/pytorch/src/transforms/prim_list_unpack_replacer.cpp
+++ b/src/frontends/pytorch/src/transforms/prim_list_unpack_replacer.cpp
@@ -27,6 +27,35 @@ PrimListUnpackReplacer::PrimListUnpackReplacer() {
             return false;
 
         auto input_node = list_unpack->input(0).get_source_output().get_node_shared_ptr();
+        if (auto torch_split = cast_fw_node(input_node, "aten::split")) {
+            if (torch_split->get_input_source_output(1).get_shape() == Shape{}) {
+                // Create split_lenghts tensor from split_size int,
+                // allow for last chunk to be smaller if data cannot equally divisible.
+                auto split_size = torch_split->get_input_source_output(1);
+                // Using number of ListUnpack outputs.
+                auto num_out_m_1 = opset8::Constant::create(split_size.get_element_type(),
+                                                            Shape{1},
+                                                            {list_unpack->get_output_size() - 1});
+                auto const_neg_1 = opset8::Constant::create(split_size.get_element_type(), Shape{1}, {-1});
+                auto split_lenghts_m_1 = std::make_shared<opset8::Tile>(split_size, num_out_m_1);
+                NodeVector concat_inputs{split_lenghts_m_1, const_neg_1};
+                auto split_lenghts = std::make_shared<opset8::Concat>(concat_inputs, 0);
+                auto split = std::make_shared<opset8::VariadicSplit>(torch_split->get_input_source_output(0),
+                                                                     torch_split->get_input_source_output(2),
+                                                                     split_lenghts);
+                copy_runtime_info({list_unpack, input_node}, split);
+                replace_node(list_unpack, split);
+            } else {
+                auto split = std::make_shared<opset8::VariadicSplit>(torch_split->get_input_source_output(0),
+                                                                     torch_split->get_input_source_output(2),
+                                                                     torch_split->get_input_source_output(1));
+                copy_runtime_info({list_unpack, input_node}, split);
+                replace_node(list_unpack, split);
+            }
+
+            return true;
+        }
+
         if (auto split_with_sizes = cast_fw_node(input_node, "aten::split_with_sizes")) {
             auto split = std::make_shared<opset8::VariadicSplit>(split_with_sizes->get_input_source_output(0),
                                                                  split_with_sizes->get_input_source_output(2),

--- a/src/frontends/pytorch/src/transforms/prim_list_unpack_replacer.cpp
+++ b/src/frontends/pytorch/src/transforms/prim_list_unpack_replacer.cpp
@@ -28,6 +28,9 @@ PrimListUnpackReplacer::PrimListUnpackReplacer() {
 
         auto input_node = list_unpack->input(0).get_source_output().get_node_shared_ptr();
         if (auto torch_split = cast_fw_node(input_node, "aten::split")) {
+            if (torch_split->input(1).get_partial_shape().is_dynamic()) {
+                return false;
+            }
             if (torch_split->get_input_source_output(1).get_shape() == Shape{}) {
                 // Create split_lenghts tensor from split_size int,
                 // allow for last chunk to be smaller if data cannot equally divisible.

--- a/tests/layer_tests/pytorch_tests/test_split.py
+++ b/tests/layer_tests/pytorch_tests/test_split.py
@@ -1,0 +1,73 @@
+# Copyright (C) 2018-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import numpy as np
+import torch
+
+
+from pytorch_layer_test_class import PytorchLayerTest
+
+class TestSplit(PytorchLayerTest):
+    def _prepare_input(self):
+        return (np.random.randn(1, 10, 224, 224).astype(np.float32),)
+
+    def create_model_split_getitem(self):
+        class aten_split(torch.nn.Module):
+            def __init__(self, split, axis, getitem):
+                self.split = split
+                self.axis = axis
+                self.getitem = getitem
+                super(aten_split, self).__init__()
+
+            def forward(self, input):
+                return torch.split(input, self.split, self.axis)[self.getitem]
+
+        ref_net = None
+
+        return (
+            aten_split(self.split_param, self.axis, self.getitem),
+            ref_net,
+            "aten::split",
+        )
+
+    def create_model_split_listunpack(self):
+        class aten_split(torch.nn.Module):
+            def __init__(self, split, axis):
+                self.split = split
+                self.axis = axis
+                super(aten_split, self).__init__()
+
+            def forward(self, input):
+                # Hardcode to test with ListUnpack
+                a, b, c, d, e = torch.split(input, self.split, self.axis)
+                return b
+
+        ref_net = None
+
+        return aten_split(self.split_param, self.axis), ref_net, "aten::split"
+
+    # Test case - (split_param, axis), always split into 5 due to hardcoded number of outputs in ListUnpack test. 
+    test_cases = [
+        (2, 1),
+        (45, 2),
+        (45, -1),
+        ([2, 2, 2, 2, 2], 1),
+        ([200, 20, 1, 1, 2], 2),
+        ([20, 200, 1, 1, 2], 3),
+    ]
+    @pytest.mark.parametrize("params", test_cases)
+    @pytest.mark.parametrize("getitem", [-5, -2, -1, 0, 1, 4])
+    @pytest.mark.nightly
+    def test_split_getitem(self, params, getitem, ie_device, precision, ir_version):
+        (self.split_param, self.axis) = params
+        self.getitem = getitem
+        self._test(*self.create_model_split_getitem(), ie_device, precision, ir_version)
+
+    @pytest.mark.parametrize("params", test_cases)
+    @pytest.mark.nightly
+    def test_split_listunpack(self, params, ie_device, precision, ir_version):
+        (self.split_param, self.axis) = params
+        self._test(
+            *self.create_model_split_listunpack(), ie_device, precision, ir_version
+        )

--- a/tests/layer_tests/pytorch_tests/test_split.py
+++ b/tests/layer_tests/pytorch_tests/test_split.py
@@ -54,7 +54,7 @@ class TestSplit(PytorchLayerTest):
         (45, -1),
         ([2, 2, 2, 2, 2], 1),
         ([200, 20, 1, 1, 2], 2),
-        ([20, 200, 1, 1, 2], 3),
+        ([20, 200, 1, 1, 2], -1),
     ]
     @pytest.mark.parametrize("params", test_cases)
     @pytest.mark.parametrize("getitem", [-5, -2, -1, 0, 1, 4])


### PR DESCRIPTION
Add tests and transformations for:
* `aten::split` with `aten::__getitem__`
* `aten::split` with `prim::ListUnpack`

There is at least 1 additional transformation that needs to be done: `aten::split`+`aten::cat`

Tickets:
* `aten::split`: 94272
Also releated:
* `aten::__getitem__`: 94276
* `prim::ListUnpack`: 94264