### PR TITLE
Add aten::adaptive_avg_pool3d operator and layer tests

### DIFF
--- a/src/frontends/pytorch/src/op/adaptive_avg_pool3d.cpp
+++ b/src/frontends/pytorch/src/op/adaptive_avg_pool3d.cpp
@@ -20,15 +20,14 @@ OutputVector translate_adaptive_avg_pool3d(NodeContext& context) {
     auto input_tensor = context.get_input(0);
     auto given_shape = context.get_input(1);
 
-    auto input_shape = context.mark_node(std::make_shared<opset8::ShapeOf>(input_tensor));
-    auto slice =
+    auto input_shape = context.mark_node(std::make_shared<opset8::ShapeOf>(input_tensor, element::i32));
+    auto shape_begin =
         context.mark_node(std::make_shared<opset8::Slice>(input_shape, const_0, const_neg_3, const_1, const_0));
-    auto shape_begin = context.mark_node(std::make_shared<opset8::Convert>(slice, element::i32));
     auto output_shape = context.mark_node(std::make_shared<opset8::Concat>(OutputVector{shape_begin, given_shape}, 0));
 
     auto tile = context.mark_node(std::make_shared<opset8::Tile>(input_tensor, const_tile_params));
-    auto adaptive_max_pool = context.mark_node(std::make_shared<opset8::AdaptiveAvgPool>(tile, given_shape));
-    auto reshape = context.mark_node(std::make_shared<opset8::Reshape>(adaptive_max_pool, output_shape, false));
+    auto adaptive_avg_pool = context.mark_node(std::make_shared<opset8::AdaptiveAvgPool>(tile, given_shape));
+    auto reshape = context.mark_node(std::make_shared<opset8::Reshape>(adaptive_avg_pool, output_shape, false));
 
     return {reshape};
 };

--- a/src/frontends/pytorch/src/op/adaptive_avg_pool3d.cpp
+++ b/src/frontends/pytorch/src/op/adaptive_avg_pool3d.cpp
@@ -1,0 +1,38 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "openvino/frontend/pytorch/node_context.hpp"
+#include "openvino/opsets/opset8.hpp"
+#include "utils.hpp"
+
+namespace ov {
+namespace frontend {
+namespace pytorch {
+namespace op {
+
+OutputVector translate_adaptive_avg_pool3d(NodeContext& context) {
+    auto const_tile_params = context.mark_node(opset8::Constant::create(element::i32, Shape{5}, {1, 1, 1, 1, 1}));
+    auto const_0 = context.mark_node(opset8::Constant::create(element::i32, Shape{1}, {0}));
+    auto const_1 = context.mark_node(opset8::Constant::create(element::i32, Shape{1}, {1}));
+    auto const_neg_3 = context.mark_node(opset8::Constant::create(element::i32, Shape{1}, {-3}));
+
+    auto input_tensor = context.get_input(0);
+    auto given_shape = context.get_input(1);
+
+    auto input_shape = context.mark_node(std::make_shared<opset8::ShapeOf>(input_tensor));
+    auto slice = context.mark_node(std::make_shared<opset8::Slice>(input_shape, const_0, const_neg_3, const_1, const_0));
+    auto shape_begin = context.mark_node(std::make_shared<opset8::Convert>(slice, element::i32));
+    auto output_shape = context.mark_node(std::make_shared<opset8::Concat>(OutputVector{shape_begin, given_shape}, 0));
+    
+    auto tile = context.mark_node(std::make_shared<opset8::Tile>(input_tensor, const_tile_params));
+    auto adaptive_max_pool = context.mark_node(std::make_shared<opset8::AdaptiveAvgPool>(tile, given_shape));
+    auto reshape = context.mark_node(std::make_shared<opset8::Reshape>(adaptive_max_pool, output_shape, false));
+
+    return {reshape};
+};
+
+}  // namespace op
+}  // namespace pytorch
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/pytorch/src/op/adaptive_avg_pool3d.cpp
+++ b/src/frontends/pytorch/src/op/adaptive_avg_pool3d.cpp
@@ -21,10 +21,11 @@ OutputVector translate_adaptive_avg_pool3d(NodeContext& context) {
     auto given_shape = context.get_input(1);
 
     auto input_shape = context.mark_node(std::make_shared<opset8::ShapeOf>(input_tensor));
-    auto slice = context.mark_node(std::make_shared<opset8::Slice>(input_shape, const_0, const_neg_3, const_1, const_0));
+    auto slice =
+        context.mark_node(std::make_shared<opset8::Slice>(input_shape, const_0, const_neg_3, const_1, const_0));
     auto shape_begin = context.mark_node(std::make_shared<opset8::Convert>(slice, element::i32));
     auto output_shape = context.mark_node(std::make_shared<opset8::Concat>(OutputVector{shape_begin, given_shape}, 0));
-    
+
     auto tile = context.mark_node(std::make_shared<opset8::Tile>(input_tensor, const_tile_params));
     auto adaptive_max_pool = context.mark_node(std::make_shared<opset8::AdaptiveAvgPool>(tile, given_shape));
     auto reshape = context.mark_node(std::make_shared<opset8::Reshape>(adaptive_max_pool, output_shape, false));

--- a/src/frontends/pytorch/src/op_table.cpp
+++ b/src/frontends/pytorch/src/op_table.cpp
@@ -14,6 +14,7 @@ namespace op {
 
 #define OP_CONVERTER(op) OutputVector op(NodeContext& node)
 
+OP_CONVERTER(translate_adaptive_avg_pool3d);
 OP_CONVERTER(translate_adaptive_max_pool2d);
 OP_CONVERTER(translate_add);
 OP_CONVERTER(translate_addcmul);
@@ -69,6 +70,7 @@ const std::map<std::string, CreatorFunction> get_supported_ops() {
         {"aten::_convolution", op::translate_convolution},
         {"aten::abs", op::translate_1to1_match_1_inputs<opset8::Abs>},
         {"aten::adaptive_avg_pool2d", op::translate_1to1_match_2_inputs<opset8::AdaptiveAvgPool>},
+        {"aten::adaptive_avg_pool3d", op::translate_adaptive_avg_pool3d},
         {"aten::adaptive_max_pool2d", op::translate_adaptive_max_pool2d},
         {"aten::add", op::translate_add},
         {"aten::add_", op::inplace_op<op::translate_add>},

--- a/tests/layer_tests/pytorch_tests/test_adaptive_avg_pool3d.py
+++ b/tests/layer_tests/pytorch_tests/test_adaptive_avg_pool3d.py
@@ -1,0 +1,36 @@
+# Copyright (C) 2018-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from pytorch_layer_test_class import PytorchLayerTest
+import numpy as np
+import torch
+
+
+@pytest.mark.parametrize('input_tensor', (np.random.randn(1, 2, 8, 9, 10).astype(np.float32),
+                                          np.random.randn(2, 8, 9, 10).astype(np.float32)))
+@pytest.mark.parametrize('output_size', ([5, 7, 9], 7))
+class TestAdaptiveAvgPool3D(PytorchLayerTest):
+
+    def _prepare_input(self):
+        return (self.input_tensor,)
+
+    def create_model(self, output_size):
+
+        class aten_adaptive_avg_pool3d(torch.nn.Module):
+
+            def __init__(self, output_size) -> None:
+                super().__init__()
+                self.output_size = output_size
+
+            def forward(self, input_tensor):
+                return torch.nn.functional.adaptive_avg_pool3d(input_tensor, self.output_size)
+
+        ref_net = None
+
+        return aten_adaptive_avg_pool3d(output_size), ref_net, "aten::adaptive_avg_pool3d"
+
+    @pytest.mark.nightly
+    def test_adaptive_avg_pool3d(self, ie_device, precision, ir_version, input_tensor, output_size):
+        self.input_tensor = input_tensor
+        self._test(*self.create_model(output_size), ie_device, precision, ir_version)

--- a/tests/layer_tests/pytorch_tests/test_reshape_as.py
+++ b/tests/layer_tests/pytorch_tests/test_reshape_as.py
@@ -17,14 +17,14 @@ class TestReshapeAs(PytorchLayerTest):
 
     def create_model(self):
 
-        class aten_select(torch.nn.Module):
+        class aten_reshape_as(torch.nn.Module):
 
             def forward(self, input_tensor, shape_tensor):
                 return input_tensor.reshape_as(shape_tensor)
 
         ref_net = None
 
-        return aten_select(), ref_net, "aten::reshape_as"
+        return aten_reshape_as(), ref_net, "aten::reshape_as"
 
     @pytest.mark.nightly
     def test_reshape_as(self, ie_device, precision, ir_version, input_tesnors):

--- a/tests/layer_tests/pytorch_tests/test_select.py
+++ b/tests/layer_tests/pytorch_tests/test_select.py
@@ -31,6 +31,6 @@ class TestSelect(PytorchLayerTest):
         return aten_select(input_dim, input_index), ref_net, "aten::select"
 
     @pytest.mark.nightly
-    def test_pow(self, ie_device, precision, ir_version, input_dim, input_index):
+    def test_select(self, ie_device, precision, ir_version, input_dim, input_index):
         self._test(*self.create_model(input_dim, input_index),
                    ie_device, precision, ir_version)


### PR DESCRIPTION
Details:

- `aten::adaptive_avg_pool3d` operator has been added
- layer test for this operator has been added
- small typos in layer tests for `aten::reshape_as` and `aten::select` has been corrected

Ticket:

- 95078