### PR TITLE
Add transformations for `prim::ListUnpack`

### DIFF
--- a/src/frontends/pytorch/src/frontend.cpp
+++ b/src/frontends/pytorch/src/frontend.cpp
@@ -20,6 +20,7 @@
 #include "pt_framework_node.hpp"
 #include "transformations/control_flow/unroll_if.hpp"
 #include "transforms.hpp"
+#include "transforms/append_list_unpack_replacer.hpp"
 #include "transforms/aten_cat_replacer.hpp"
 #include "transforms/aten_getitem_replacer.hpp"
 #include "transforms/prim_list_unpack_replacer.hpp"
@@ -103,6 +104,7 @@ void FrontEnd::normalize(const std::shared_ptr<ov::Model>& model) const {
     ov::pass::Manager manager;
 
     manager.register_pass<ov::frontend::pytorch::pass::AtenCatToConcat>();
+    manager.register_pass<ov::frontend::pytorch::pass::AppendListUnpackReplacer>();
     manager.register_pass<ov::frontend::pytorch::pass::PrimListUnpackReplacer>();
     manager.register_pass<ov::frontend::pytorch::pass::AtenGetItemReplacer>();
     manager.register_pass<ov::frontend::pytorch::pass::DecomposeTupleResults>();

--- a/src/frontends/pytorch/src/op/size.cpp
+++ b/src/frontends/pytorch/src/op/size.cpp
@@ -12,7 +12,7 @@ namespace pytorch {
 namespace op {
 
 OutputVector translate_size(NodeContext& context) {
-    auto shape = context.mark_node(std::make_shared<opset8::ShapeOf>(context.get_input(0)));
+    auto shape = context.mark_node(std::make_shared<opset8::ShapeOf>(context.get_input(0), element::i32));
     if (context.input_is_none(1)) {
         return shape->outputs();
     } else {

--- a/src/frontends/pytorch/src/op/size.cpp
+++ b/src/frontends/pytorch/src/op/size.cpp
@@ -12,7 +12,7 @@ namespace pytorch {
 namespace op {
 
 OutputVector translate_size(NodeContext& context) {
-    auto shape = context.mark_node(std::make_shared<opset8::ShapeOf>(context.get_input(0), element::i32));
+    auto shape = context.mark_node(std::make_shared<opset8::ShapeOf>(context.get_input(0)));
     if (context.input_is_none(1)) {
         return shape->outputs();
     } else {

--- a/src/frontends/pytorch/src/transforms/append_list_unpack_replacer.cpp
+++ b/src/frontends/pytorch/src/transforms/append_list_unpack_replacer.cpp
@@ -1,0 +1,97 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "append_list_unpack_replacer.hpp"
+
+#include <memory>
+#include <utility>
+
+#include "openvino/frontend/pytorch/visibility.hpp"
+#include "openvino/op/util/framework_node.hpp"
+#include "openvino/pass/pattern/matcher.hpp"
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+#include "utils.hpp"
+
+namespace ov {
+namespace frontend {
+namespace pytorch {
+namespace pass {
+
+AppendListUnpackReplacer::AppendListUnpackReplacer() {
+    auto list_unpack = ov::pass::pattern::wrap_type<ov::op::util::FrameworkNode>();
+
+    ov::matcher_pass_callback callback = [](ov::pass::pattern::Matcher& m) {
+        auto list_unpack = cast_fw_node(m.get_match_root(), "prim::ListUnpack");
+        if (!list_unpack)
+            return false;
+
+        OutputVector tmp_inputs;
+        NodeVector rt_copy_from{list_unpack};
+        auto input_node = list_unpack->input_value(0).get_node_shared_ptr();
+
+        // Optional aten::__getitem__ node.
+        auto getitem_node = cast_fw_node(input_node, "aten::__getitem__");
+        if (getitem_node) {
+            rt_copy_from.push_back(getitem_node);
+            input_node = getitem_node->input(0).get_source_output().get_node_shared_ptr();
+        }
+
+        while (auto append_node = cast_fw_node(input_node, "aten::append")) {
+            rt_copy_from.push_back(append_node);
+            tmp_inputs.push_back(append_node->input(1).get_source_output());
+            input_node = append_node->input(0).get_source_output().get_node_shared_ptr();
+        }
+        OutputVector inputs;
+        auto list_construct_node = cast_fw_node(input_node, "prim::ListConstruct");
+        if (!list_construct_node) {
+            return false;
+        }
+        rt_copy_from.push_back(list_construct_node);
+        for (auto& input : list_construct_node->inputs()) {
+            inputs.push_back(input.get_source_output());
+        }
+
+        inputs.insert(inputs.end(), tmp_inputs.rbegin(), tmp_inputs.rend());
+        if (getitem_node) {
+            // If aten::__getitem__, expect inputs to be equivalent of pytorch Tensor[][].
+            // Tensor selected by aten::__getitem__ index needs to be splitted in axis 0.
+            auto getitem_index_ptr = getitem_node->input_value(1).get_node_shared_ptr();
+            auto getitem_index_const = std::dynamic_pointer_cast<opset8::Constant>(getitem_index_ptr);
+            auto index_val = getitem_index_const->cast_vector<int64_t>();
+            auto index = 0;
+            if (index_val[0] >= 0) {
+                index = index_val[0];
+            } else {
+                index = inputs.size() + index_val[0];
+            }
+            auto axis_0 = opset8::Constant::create(element::i64, Shape{}, {0});
+            auto split = std::make_shared<opset8::Split>(inputs[index], axis_0, list_unpack->get_output_size());
+            NodeVector to_copy_rt{axis_0, split};
+            OutputVector res;
+            for (auto output : split->outputs()) {
+                auto squeeze = std::make_shared<opset8::Squeeze>(output, axis_0);
+                to_copy_rt.push_back(squeeze);
+                res.push_back(squeeze);
+            }
+            copy_runtime_info(rt_copy_from, to_copy_rt);
+            replace_node(list_unpack, res);
+            return true;
+        } else {
+            // Without aten::__getitem__, expect inputs to be equivalent od pytorch Tensor[].
+            // Return all inputs.
+            replace_node(list_unpack, inputs);
+            return true;
+        }
+        return false;
+    };
+
+    auto m = std::make_shared<ov::pass::pattern::Matcher>(list_unpack,
+                                                          "ov::frontend::pytorch::pass::AppendListUnpackReplacer");
+    this->register_matcher(m, callback);
+};
+
+}  // namespace pass
+}  // namespace pytorch
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/pytorch/src/transforms/append_list_unpack_replacer.hpp
+++ b/src/frontends/pytorch/src/transforms/append_list_unpack_replacer.hpp
@@ -1,0 +1,25 @@
+// Copyright (C) 2018-2022 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "openvino/frontend/pytorch/visibility.hpp"
+#include "openvino/pass/graph_rewrite.hpp"
+#include "openvino/pass/pass.hpp"
+
+namespace ov {
+namespace frontend {
+namespace pytorch {
+namespace pass {
+
+class PYTORCH_API AppendListUnpackReplacer : public ov::pass::MatcherPass {
+public:
+    OPENVINO_RTTI("ov::frontend::pytorch::pass::AppendListUnpackReplacer");
+    AppendListUnpackReplacer();
+};
+
+}  // namespace pass
+}  // namespace pytorch
+}  // namespace frontend
+}  // namespace ov

--- a/src/frontends/pytorch/src/transforms/aten_getitem_replacer.cpp
+++ b/src/frontends/pytorch/src/transforms/aten_getitem_replacer.cpp
@@ -76,9 +76,6 @@ AtenGetItemReplacer::AtenGetItemReplacer() {
                 replace_node(getitem, split);
             } else {
                 auto getitem_index_ptr = getitem->input_value(1).get_node_shared_ptr();
-                if (!cast_fw_node(getitem_index_ptr, "prim::Constant")) {
-                    return false;
-                }
                 auto getitem_index_const = std::dynamic_pointer_cast<opset8::Constant>(getitem_index_ptr);
                 auto index_val = getitem_index_const->cast_vector<int64_t>();
                 auto split = std::make_shared<opset8::VariadicSplit>(torch_split->get_input_source_output(0),

--- a/src/frontends/pytorch/src/transforms/aten_getitem_replacer.cpp
+++ b/src/frontends/pytorch/src/transforms/aten_getitem_replacer.cpp
@@ -26,9 +26,6 @@ AtenGetItemReplacer::AtenGetItemReplacer() {
         auto getitem = cast_fw_node(m.get_match_root(), "aten::__getitem__");
         if (!getitem)
             return false;
-        auto getitem_index_ptr = getitem->input_value(1).get_node_shared_ptr();
-        auto getitem_index_const = std::dynamic_pointer_cast<opset8::Constant>(getitem_index_ptr);
-        auto index_val = getitem_index_const->cast_vector<int64_t>();
 
         auto input_node = getitem->input_value(0).get_node_shared_ptr();
         if (auto torch_split = cast_fw_node(input_node, "aten::split")) {
@@ -78,6 +75,12 @@ AtenGetItemReplacer::AtenGetItemReplacer() {
                 copy_runtime_info({getitem, input_node}, split);
                 replace_node(getitem, split);
             } else {
+                auto getitem_index_ptr = getitem->input_value(1).get_node_shared_ptr();
+                if (!cast_fw_node(getitem_index_ptr, "prim::Constant")) {
+                    return false;
+                }
+                auto getitem_index_const = std::dynamic_pointer_cast<opset8::Constant>(getitem_index_ptr);
+                auto index_val = getitem_index_const->cast_vector<int64_t>();
                 auto split = std::make_shared<opset8::VariadicSplit>(torch_split->get_input_source_output(0),
                                                                      torch_split->get_input_source_output(2),
                                                                      torch_split->get_input_source_output(1));

--- a/tests/layer_tests/pytorch_tests/test_listunpack.py
+++ b/tests/layer_tests/pytorch_tests/test_listunpack.py
@@ -1,0 +1,122 @@
+# Copyright (C) 2018-2022 Intel Corporation
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import List
+import pytest
+import numpy as np
+import torch
+
+
+from pytorch_layer_test_class import PytorchLayerTest
+
+
+class TestListUnpack(PytorchLayerTest):
+    def _prepare_input(self):
+        return (
+            np.random.randn(8, 3, 512, 512),
+            np.random.randn(1, 3, 224, 224),
+            np.random.randn(10, 1, 8, 8),
+            np.random.randn(1, 1, 1, 1),
+        )
+
+    def create_model_size_listunpack(self):
+        class prim_listunpack(torch.nn.Module):
+            def forward(self, in1, in2, in3, in4):
+                a, b, c, d = in1.size()
+                return a, b, c, d
+
+        ref_net = None
+
+        return (
+            prim_listunpack(),
+            ref_net,
+            "prim::ListUnpack",
+        )
+
+    def create_model_size_slice_listunpack(self, slices):
+        class prim_listunpack(torch.nn.Module):
+            def __init__(self, slices):
+                self.start = slices[0]
+                self.stop = slices[1]
+                self.step = slices[2]
+                super(prim_listunpack, self).__init__()
+
+            def forward(self, in1, in2, in3, in4):
+                a, b = in1.size()[self.start : self.stop : self.step]
+                return a, b
+
+        ref_net = None
+
+        return prim_listunpack(slices), ref_net, "prim::ListUnpack"
+
+    def create_model_listconstruct_append_listunpack(self):
+        class prim_listunpack(torch.nn.Module):
+            def forward(self, in1, in2, in3, in4):
+                in_list = [in1, in2]
+                in_list.append(in3)
+                in_list.append(in4)
+                a, b, c, d = in_list
+                return a, b, c, d
+
+        ref_net = None
+
+        return prim_listunpack(), ref_net, "prim::ListUnpack"
+
+    def create_model_listconstruct_getitem_listunpack(self, idx):
+        class prim_listunpack(torch.nn.Module):
+            def __init__(self, idx):
+                self.idx = idx
+                super(prim_listunpack, self).__init__()
+
+            def forward(self, in1, in2, in3, in4):
+                items: List[List[int]] = []
+                items.append(in1.size())
+                items.append(in2.size())
+                items.append(in3.size())
+                items.append(in4.size())
+                getitem_0 = items[self.idx]
+                a, b, c, d = getitem_0
+                return a, b, c, d
+
+        ref_net = None
+
+        return prim_listunpack(idx), ref_net, "prim::ListUnpack"
+
+    @pytest.mark.nightly
+    def test_size_listunpack(self, ie_device, precision, ir_version):
+        self._test(
+            *self.create_model_size_listunpack(), ie_device, precision, ir_version
+        )
+
+    @pytest.mark.parametrize(
+        "slices", [(0, 2, 1), (0, 4, 2), (-1, -3, -1), (-3, -1, 1)]
+    )
+    @pytest.mark.nightly
+    def test_size_slice_listunpack(self, slices, ie_device, precision, ir_version):
+        self._test(
+            *self.create_model_size_slice_listunpack(slices),
+            ie_device,
+            precision,
+            ir_version
+        )
+
+    @pytest.mark.nightly
+    def test_listconstruct_append_listunpack(self, ie_device, precision, ir_version):
+        self._test(
+            *self.create_model_listconstruct_append_listunpack(),
+            ie_device,
+            precision,
+            ir_version
+        )
+
+    @pytest.mark.parametrize("idx", [-4, -3, -2, -1, 0, 1, 2, 3])
+    @pytest.mark.nightly
+    def test_listconstruct_getitem_listunpack(
+        self, idx, ie_device, precision, ir_version
+    ):
+        self._test(
+            *self.create_model_listconstruct_getitem_listunpack(idx),
+            ie_device,
+            precision,
+            ir_version
+        )


### PR DESCRIPTION
Add transformations/replacer for following op combinations:

- `aten::size`+`aten::slice`+`prim::ListUnpack`
- T[] `prim::ListConstruct`+`aten::append`+`prim::ListUnpack`
- T[][] `prim::ListConstruct`+`aten::append`+`aten::__getitem__`+`prim::ListUnpack`

\+ bugfix for `aten::__getitem__`

Know missing `prim::ListUnpack` transformations that will be added in future PR's:
- `prim::ListConstruct`+`aten::meshgrid`+`prim::ListUnpack`
- `aten::tensor_split`+`prim::ListUnpack`