### PR TITLE
add trunc mode to div

### DIFF
--- a/src/frontends/pytorch/src/op/div.cpp
+++ b/src/frontends/pytorch/src/op/div.cpp
@@ -6,7 +6,6 @@
 #include "openvino/opsets/opset8.hpp"
 #include "utils.hpp"
 
-
 namespace ov {
 namespace frontend {
 namespace pytorch {
@@ -23,6 +22,11 @@ OutputVector translate_div(NodeContext& context) {
         } else if (rounding_mode == "trunc") {
             const auto convert = context.mark_node(std::make_shared<opset8::Convert>(res, element::i64));
             res = context.mark_node(std::make_shared<opset8::ConvertLike>(convert, x));
+        } else {
+            FRONT_END_OP_CONVERSION_CHECK(false,
+                                          "Openvino Pytorch Frontend doesn't support rounding mode ",
+                                          rounding_mode,
+                                          " for aten::div");
         }
     }
     return {res};

--- a/src/frontends/pytorch/src/op/div.cpp
+++ b/src/frontends/pytorch/src/op/div.cpp
@@ -6,6 +6,7 @@
 #include "openvino/opsets/opset8.hpp"
 #include "utils.hpp"
 
+
 namespace ov {
 namespace frontend {
 namespace pytorch {
@@ -19,12 +20,9 @@ OutputVector translate_div(NodeContext& context) {
         auto rounding_mode = context.const_input<std::string>(2);
         if (rounding_mode == "floor") {
             res = context.mark_node(std::make_shared<opset8::Floor>(res));
-        } else {
-            // TODO: support mode "trunc", need to extend openvino opset for that 
-            FRONT_END_OP_CONVERSION_CHECK(false,
-                                          "Openvino Pytorch Frontend doesn't support rounding mode ",
-                                          rounding_mode,
-                                          " for aten::div");
+        } else if (rounding_mode == "trunc") {
+            const auto convert = context.mark_node(std::make_shared<opset8::Convert>(res, element::i64));
+            res = context.mark_node(std::make_shared<opset8::ConvertLike>(convert, x));
         }
     }
     return {res};

--- a/tests/layer_tests/pytorch_tests/test_div.py
+++ b/tests/layer_tests/pytorch_tests/test_div.py
@@ -45,6 +45,7 @@ class Testdiv(PytorchLayerTest):
     @pytest.mark.parametrize('rounding_mode', ([
         None,
         "floor",
+        "trunc"
     ]))
 
     @pytest.mark.nightly

--- a/tests/layer_tests/pytorch_tests/test_div.py
+++ b/tests/layer_tests/pytorch_tests/test_div.py
@@ -6,9 +6,8 @@ import numpy as np
 from pytorch_layer_test_class import PytorchLayerTest
 
 
-class Testdiv(PytorchLayerTest):
+class TestDiv(PytorchLayerTest):
     def _prepare_input(self):
-        # return (self.input_tensor, self.other_tensor)
         return (self.input_array.astype(self.input_type), self.other_array.astype(self.other_type))
 
     def create_model(self, rounding_mode):
@@ -55,7 +54,7 @@ class Testdiv(PytorchLayerTest):
     ]))
 
     @pytest.mark.nightly
-    def test_div_random(self, input_array, input_type, other_array, other_type, rounding_mode, ie_device, precision, ir_version):
+    def test_div(self, input_array, input_type, other_array, other_type, rounding_mode, ie_device, precision, ir_version):
         self.input_array = input_array
         self.input_type = input_type
         self.other_array = other_array

--- a/tests/layer_tests/pytorch_tests/test_div.py
+++ b/tests/layer_tests/pytorch_tests/test_div.py
@@ -9,8 +9,7 @@ from pytorch_layer_test_class import PytorchLayerTest
 class Testdiv(PytorchLayerTest):
     def _prepare_input(self):
         # return (self.input_tensor, self.other_tensor)
-        return (np.random.rand(*self.input_shape).astype(self.input_type),
-                np.random.rand(*self.other_shape).astype(self.other_type))
+        return (self.input_array.astype(self.input_type), self.other_array.astype(self.other_type))
 
     def create_model(self, rounding_mode):
 
@@ -28,19 +27,26 @@ class Testdiv(PytorchLayerTest):
 
         return aten_div(rounding_mode), ref_net, "aten::div"
 
-    @pytest.mark.parametrize(("input_shape", "input_type"), [
-        [(5, 5), np.float32],
-        [(5, 5, 1), np.float32],
-        [(1, 1, 5, 5), np.float32],
-
+    @pytest.mark.parametrize(("input_array", "other_array"), [
+        [np.random.rand(5, 5), np.random.rand(1)],
+        [np.random.rand(5, 5, 1), np.random.rand(1)],
+        [np.random.rand(1, 1, 5, 5), np.random.rand(1)],
+        [np.random.rand(5, 5, 1), np.random.rand(5, 1)],
+        [np.random.rand(5, 5), np.random.rand(5, 5)],
+        [np.array([ 0.7620,  2.5548, -0.5944, -0.7438,  0.9274]), np.array(0.5)],
+        [np.array([[-0.3711, -1.9353, -0.4605, -0.2917],
+                   [ 0.1815, -1.0111,  0.9805, -1.5923],
+                   [ 0.1062,  1.4581,  0.7759, -1.2344],
+                   [-0.1830, -0.0313,  1.1908, -1.4757]]),
+         np.array([0.8032,  0.2930, -0.8113, -0.2308])]
     ])
-    @pytest.mark.parametrize(("other_shape", "other_type"), [
-        [(1, 1), np.int32],
-        [(5, 1), np.int32],
-        [(1, 5), np.int32],
-        [(1, 1), np.float32],
-        [(5, 1), np.float32],
-        [(1, 5), np.float32],
+    @pytest.mark.parametrize(("input_type"), [
+        np.int32,
+        np.float32
+    ])
+    @pytest.mark.parametrize(("other_type"), [
+        np.int32,
+        np.float32
     ])
     @pytest.mark.parametrize('rounding_mode', ([
         None,
@@ -49,9 +55,9 @@ class Testdiv(PytorchLayerTest):
     ]))
 
     @pytest.mark.nightly
-    def test_div(self, input_shape, input_type, other_shape, other_type, rounding_mode, ie_device, precision, ir_version):
-        self.input_shape = input_shape
+    def test_div_random(self, input_array, input_type, other_array, other_type, rounding_mode, ie_device, precision, ir_version):
+        self.input_array = input_array
         self.input_type = input_type
-        self.other_shape = other_shape
+        self.other_array = other_array
         self.other_type = other_type
         self._test(*self.create_model(rounding_mode), ie_device, precision, ir_version)


### PR DESCRIPTION
## Details
Follow up PR to the https://github.com/slyalin/openvino/pull/66.
* [x] add support for `trunc` mode to the `aten::div` operation

## Ticket:
94304