### PR TITLE
Add support for TPP MLIR

### DIFF
--- a/src/common/transformations/CMakeLists.txt
+++ b/src/common/transformations/CMakeLists.txt
@@ -32,7 +32,18 @@ ov_build_target_faster(${TARGET_NAME}_obj
 
 target_compile_features(${TARGET_NAME}_obj PUBLIC cxx_std_17)
 
-target_link_libraries(${TARGET_NAME}_obj PRIVATE openvino::reference openvino::itt openvino::core::dev openvino::shape_inference)
+# If TPP-MLIR is in library path, add it to the dependencies
+if (TPP_MLIR_DIR)
+    message(STATUS "TPP-MLIR at ${TPP_MLIR_DIR}")
+    add_compile_definitions(TPP_MLIR)
+    set(TPP_MLIR_LIBS
+            TPPPipeline
+            tpp_xsmm_runner_utils
+        )
+    target_link_directories(${TARGET_NAME}_obj PRIVATE ${TPP_MLIR_DIR})
+endif()
+
+target_link_libraries(${TARGET_NAME}_obj PRIVATE openvino::reference openvino::itt openvino::core::dev openvino::shape_inference ${TPP_MLIR_LIBS})
 
 target_include_directories(${TARGET_NAME}_obj PRIVATE "${PUBLIC_HEADERS_DIR}"
                                                       "${CMAKE_CURRENT_SOURCE_DIR}/src"

--- a/src/common/transformations/src/transformations/mlir/convert.cpp
+++ b/src/common/transformations/src/transformations/mlir/convert.cpp
@@ -63,7 +63,7 @@ static void prepareMLIRKernelWithoutWrapper(mlir::OwningOpRef<mlir::ModuleOp>& m
     // A set of default passes that lower any input IR to LLVM
     PassManager pm(module->getContext());
 
-#if 0  // TODO: if TPP is available
+#ifdef TPP_MLIR // If TPP is available
 
     tpp::DefaultPipelineOptions defPipelineOpts{defGpuBackend};
     pm.addPass(tpp::createDefaultPipeline(defPipelineOpts));


### PR DESCRIPTION
For now it doesn't do much, since the IR we get has no GEMMs in it, but it does enable that path, so we can develop it in parallel. Both MLIR and LIBXSMM are already in the build, so no need to add them.

Long term we want to not have this dependency, though, so this is just a way to get things going.