### PR TITLE
Pre-bufferization cleanup

### DIFF
--- a/src/common/transformations/src/transformations/mlir/mlir_op.cpp
+++ b/src/common/transformations/src/transformations/mlir/mlir_op.cpp
@@ -71,6 +71,11 @@ void prepareMLIRKernelWithoutWrapper(mlir::OwningOpRef<mlir::ModuleOp>& module) 
 
 #else  // Simplified default lowering to LLVM from LLVM tests
 
+    // Cleanup before bufferization.
+    // Simplifies IR to allow better bufferization.
+    pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+    pm.addNestedPass<func::FuncOp>(createCSEPass());
+
     // Remove empty tensors to avoid converting them into temporary buffers.
     pm.addPass(bufferization::createEmptyTensorEliminationPass());
 


### PR DESCRIPTION
Adds cleanup right before bufferization to eliminate temporary buffer creation in multi-node pattern lowering.