### PR TITLE
TPP-MLIR as out-of-tree dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,15 @@ function(ov_developer_package_export_targets)
         "A list of OpenVINO Developer Package exported targets" FORCE)
 endfunction()
 
+
+#
+# TPP-MLIR
+#
+
+# enables tpp-mlir for temporary MLIR lowering CPU pipeline
+# FIXME: Move to all-upsteram lowering into XSMM/DNN/MKL
+include(cmake/tpp-mlir.cmake)
+
 #
 # Build
 #

--- a/cmake/tpp-mlir.cmake
+++ b/cmake/tpp-mlir.cmake
@@ -6,15 +6,36 @@ if (TPP_MLIR_DIR)
     add_compile_definitions(TPP_MLIR)
     set(TPP_MLIR_LIBS
             TPPPipeline
+            TPPCheckDialect
+            TPPCheckToLoops
+            TPPGPU
+            TPPIR
+            TPPLinalgToFunc
+            TPPLinalgToXSMM
+            TPPPerfDialect
+            TPPPerfToFunc
+            TPPPerfToLoop
+            TPPRunner
+            TPPTestLib
+            TPPTransforms
+            TPPTransformsUtils
+            TPPXsmmDialect
+            TPPXsmmToFunc
+            xsmm
             tpp_xsmm_runner_utils
         )
-    function(enable_tpp_mlir target)
+    function(add_tpp_mlir_includes target)
         target_include_directories(${target} PRIVATE ${TPP_MLIR_DIR}/../include ${TPP_MLIR_DIR}/include)
+    endfunction()
+    function(add_tpp_mlir_libs target)
         target_link_directories(${target} PRIVATE ${TPP_MLIR_DIR}/lib)
         target_link_libraries(${target} PRIVATE ${TPP_MLIR_LIBS})
     endfunction()
 else()
-    function(enable_tpp_mlir target)
+    function(add_tpp_mlir_includes target)
+        message(DEBUG "TPP-MLIR not enabled, skipping ${target}")
+    endfunction()
+    function(add_tpp_mlir_libs target)
         message(DEBUG "TPP-MLIR not enabled, skipping ${target}")
     endfunction()
 endif()

--- a/cmake/tpp-mlir.cmake
+++ b/cmake/tpp-mlir.cmake
@@ -5,16 +5,17 @@ if (TPP_MLIR_DIR)
     message(STATUS "TPP-MLIR at ${TPP_MLIR_DIR}")
     add_compile_definitions(TPP_MLIR)
     set(TPP_MLIR_LIBS
-            TPPPipeline
             TPPCheckDialect
             TPPCheckToLoops
             TPPGPU
             TPPIR
             TPPLinalgToFunc
             TPPLinalgToXSMM
+            TPPPassBundles
             TPPPerfDialect
             TPPPerfToFunc
             TPPPerfToLoop
+            TPPPipeline
             TPPRunner
             TPPTestLib
             TPPTransforms

--- a/cmake/tpp-mlir.cmake
+++ b/cmake/tpp-mlir.cmake
@@ -1,0 +1,20 @@
+# If TPP-MLIR is in library path, add it to the dependencies
+# This should be the build directory, not the source or the 'lib'
+# FIXME: Make this an actual CMake discovery
+if (TPP_MLIR_DIR)
+    message(STATUS "TPP-MLIR at ${TPP_MLIR_DIR}")
+    add_compile_definitions(TPP_MLIR)
+    set(TPP_MLIR_LIBS
+            TPPPipeline
+            tpp_xsmm_runner_utils
+        )
+    function(enable_tpp_mlir target)
+        target_include_directories(${target} PRIVATE ${TPP_MLIR_DIR}/../include ${TPP_MLIR_DIR}/include)
+        target_link_directories(${target} PRIVATE ${TPP_MLIR_DIR}/lib)
+        target_link_libraries(${target} PRIVATE ${TPP_MLIR_LIBS})
+    endfunction()
+else()
+    function(enable_tpp_mlir target)
+        message(DEBUG "TPP-MLIR not enabled, skipping ${target}")
+    endfunction()
+endif()

--- a/cmake/tpp-mlir.cmake
+++ b/cmake/tpp-mlir.cmake
@@ -5,17 +5,17 @@ if (TPP_MLIR_DIR)
     message(STATUS "TPP-MLIR at ${TPP_MLIR_DIR}")
     add_compile_definitions(TPP_MLIR)
     set(TPP_MLIR_LIBS
+            TPPPipeline
+            TPPPassBundles
             TPPCheckDialect
             TPPCheckToLoops
             TPPGPU
             TPPIR
             TPPLinalgToFunc
             TPPLinalgToXSMM
-            TPPPassBundles
             TPPPerfDialect
             TPPPerfToFunc
             TPPPerfToLoop
-            TPPPipeline
             TPPRunner
             TPPTestLib
             TPPTransforms

--- a/cmake/tpp-mlir.cmake
+++ b/cmake/tpp-mlir.cmake
@@ -5,6 +5,7 @@ if (TPP_MLIR_DIR)
     message(STATUS "TPP-MLIR at ${TPP_MLIR_DIR}")
     add_compile_definitions(TPP_MLIR)
     set(TPP_MLIR_LIBS
+            # Keep the next two libs at the top of the list to avoid undefined references at link time
             TPPPipeline
             TPPPassBundles
             TPPCheckDialect

--- a/samples/cpp/benchmark/sync_benchmark/CMakeLists.txt
+++ b/samples/cpp/benchmark/sync_benchmark/CMakeLists.txt
@@ -5,5 +5,3 @@
 ov_add_sample(NAME sync_benchmark
               SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/main.cpp"
               DEPENDENCIES ie_samples_utils)
-
-enable_tpp_mlir(sync_benchmark)

--- a/samples/cpp/benchmark/sync_benchmark/CMakeLists.txt
+++ b/samples/cpp/benchmark/sync_benchmark/CMakeLists.txt
@@ -5,3 +5,5 @@
 ov_add_sample(NAME sync_benchmark
               SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/main.cpp"
               DEPENDENCIES ie_samples_utils)
+
+enable_tpp_mlir(sync_benchmark)

--- a/scripts/build_mlir.sh
+++ b/scripts/build_mlir.sh
@@ -1,0 +1,14 @@
+# run it from llvm-project/build directory
+
+cmake -G Ninja ../llvm    \
+    -DLLVM_ENABLE_PROJECTS="mlir" \
+    -DLLVM_BUILD_EXAMPLES=ON \
+    -DLLVM_INSTALL_UTILS=ON \
+    -DLLVM_TARGETS_TO_BUILD="host" \
+    -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+    -DLLVM_ENABLE_ASSERTIONS=ON \
+    -DCMAKE_C_COMPILER=clang \
+    -DCMAKE_CXX_COMPILER=clang++ \
+    -DLLVM_USE_LINKER=lld
+
+ninja

--- a/scripts/build_mlir.sh
+++ b/scripts/build_mlir.sh
@@ -1,4 +1,6 @@
-# run it from llvm-project/build directory
+#!/bin/bash
+
+# Run it in llvm-project/build directory
 
 cmake -G Ninja ../llvm    \
     -DLLVM_ENABLE_PROJECTS="mlir" \

--- a/scripts/build_tpp_mlir.sh
+++ b/scripts/build_tpp_mlir.sh
@@ -1,0 +1,12 @@
+# run it from tpp-mlir/build subdirectory
+# set CUSTOM_LLVM_ROOT to llvm-project/build directory
+
+cmake -G Ninja .. \
+   -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+   -DMLIR_DIR=$CUSTOM_LLVM_ROOT/lib/cmake/mlir \
+   -DLLVM_EXTERNAL_LIT=$CUSTOM_LLVM_ROOT/bin/llvm-lit \
+   -DCMAKE_C_COMPILER=clang \
+   -DCMAKE_CXX_COMPILER=clang++ \
+   -DLLVM_USE_LINKER=lld
+
+cmake --build . --target check-tpp

--- a/scripts/build_tpp_mlir.sh
+++ b/scripts/build_tpp_mlir.sh
@@ -1,5 +1,7 @@
-# run it from tpp-mlir/build subdirectory
-# set CUSTOM_LLVM_ROOT to llvm-project/build directory
+#!/bin/bash
+
+# Run it in tpp-mlir/build subdirectory
+# Set CUSTOM_LLVM_ROOT to llvm-project/build directory
 
 cmake -G Ninja .. \
    -DCMAKE_BUILD_TYPE=RelWithDebInfo \

--- a/src/cmake/openvino.cmake
+++ b/src/cmake/openvino.cmake
@@ -65,6 +65,8 @@ target_link_libraries(${TARGET_NAME} PRIVATE openvino::reference
                                              Threads::Threads
                                              ${MLIR_OPENVINO_LIBS})
 
+add_tpp_mlir_libs(${TARGET_NAME})
+
 if (TBBBIND_2_5_FOUND)
     target_link_libraries(${TARGET_NAME} PRIVATE ${TBBBIND_2_5_IMPORTED_TARGETS})
 endif()

--- a/src/cmake/openvino.cmake
+++ b/src/cmake/openvino.cmake
@@ -41,31 +41,17 @@ target_include_directories(${TARGET_NAME} PUBLIC
 
 find_package(MLIR REQUIRED CONFIG)
 
-set(MLIR_OPENVINO_LIBS
-        MLIRAnalysis
-        MLIRExecutionEngine
-        MLIRIR
-        MLIRJitRunner
-        MLIRLLVMDialect
-        MLIRLLVMToLLVMIRTranslation
-        MLIRToLLVMIRTranslationRegistration
-        MLIRParser
-        MLIRTargetLLVMIRExport
-        MLIRSupport
-        MLIROptLib
-        LLVMX86AsmParser
-        MLIRFuncDialect
-        MLIRFuncAllExtensions
-        MLIRUBToLLVM)
+get_property(MLIR_ALL_LIBS GLOBAL PROPERTY MLIR_ALL_LIBS)
 
 target_link_libraries(${TARGET_NAME} PRIVATE openvino::reference
                                              openvino::shape_inference
                                              openvino::pugixml
                                              ${CMAKE_DL_LIBS}
                                              Threads::Threads
-                                             ${MLIR_OPENVINO_LIBS})
+                                             ${MLIR_ALL_LIBS})
 
 add_tpp_mlir_libs(${TARGET_NAME})
+
 
 if (TBBBIND_2_5_FOUND)
     target_link_libraries(${TARGET_NAME} PRIVATE ${TBBBIND_2_5_IMPORTED_TARGETS})

--- a/src/common/transformations/CMakeLists.txt
+++ b/src/common/transformations/CMakeLists.txt
@@ -32,14 +32,15 @@ ov_build_target_faster(${TARGET_NAME}_obj
 
 target_compile_features(${TARGET_NAME}_obj PUBLIC cxx_std_17)
 
-enable_tpp_mlir(${TARGET_NAME}_obj)
-
 target_link_libraries(${TARGET_NAME}_obj PRIVATE openvino::reference openvino::itt openvino::core::dev openvino::shape_inference)
 
 target_include_directories(${TARGET_NAME}_obj PRIVATE "${PUBLIC_HEADERS_DIR}"
                                                       "${CMAKE_CURRENT_SOURCE_DIR}/src"
                                                       "${MLIR_INCLUDE_DIRS}"
                                                       "${LLVM_INCLUDE_DIRS}")
+
+add_tpp_mlir_includes(${TARGET_NAME}_obj)
+
 
 ov_add_clang_format_target(${TARGET_NAME}_clang FOR_TARGETS ${TARGET_NAME}_obj)
 

--- a/src/common/transformations/CMakeLists.txt
+++ b/src/common/transformations/CMakeLists.txt
@@ -32,7 +32,18 @@ ov_build_target_faster(${TARGET_NAME}_obj
 
 target_compile_features(${TARGET_NAME}_obj PUBLIC cxx_std_17)
 
-target_link_libraries(${TARGET_NAME}_obj PRIVATE openvino::reference openvino::itt openvino::core::dev openvino::shape_inference)
+# If TPP-MLIR is in library path, add it to the dependencies
+if (TPP_MLIR_DIR)
+    message(STATUS "TPP-MLIR at ${TPP_MLIR_DIR}")
+    add_compile_definitions(TPP_MLIR)
+    set(TPP_MLIR_LIBS
+            TPPPipeline
+            tpp_xsmm_runner_utils
+        )
+    target_link_directories(${TARGET_NAME}_obj PRIVATE ${TPP_MLIR_DIR})
+endif()
+
+target_link_libraries(${TARGET_NAME}_obj PRIVATE openvino::reference openvino::itt openvino::core::dev openvino::shape_inference ${TPP_MLIR_LIBS})
 
 target_include_directories(${TARGET_NAME}_obj PRIVATE "${PUBLIC_HEADERS_DIR}"
                                                       "${CMAKE_CURRENT_SOURCE_DIR}/src"

--- a/src/common/transformations/CMakeLists.txt
+++ b/src/common/transformations/CMakeLists.txt
@@ -32,18 +32,9 @@ ov_build_target_faster(${TARGET_NAME}_obj
 
 target_compile_features(${TARGET_NAME}_obj PUBLIC cxx_std_17)
 
-# If TPP-MLIR is in library path, add it to the dependencies
-if (TPP_MLIR_DIR)
-    message(STATUS "TPP-MLIR at ${TPP_MLIR_DIR}")
-    add_compile_definitions(TPP_MLIR)
-    set(TPP_MLIR_LIBS
-            TPPPipeline
-            tpp_xsmm_runner_utils
-        )
-    target_link_directories(${TARGET_NAME}_obj PRIVATE ${TPP_MLIR_DIR})
-endif()
+enable_tpp_mlir(${TARGET_NAME}_obj)
 
-target_link_libraries(${TARGET_NAME}_obj PRIVATE openvino::reference openvino::itt openvino::core::dev openvino::shape_inference ${TPP_MLIR_LIBS})
+target_link_libraries(${TARGET_NAME}_obj PRIVATE openvino::reference openvino::itt openvino::core::dev openvino::shape_inference)
 
 target_include_directories(${TARGET_NAME}_obj PRIVATE "${PUBLIC_HEADERS_DIR}"
                                                       "${CMAKE_CURRENT_SOURCE_DIR}/src"

--- a/src/common/transformations/src/transformations/mlir/convert.cpp
+++ b/src/common/transformations/src/transformations/mlir/convert.cpp
@@ -63,7 +63,7 @@ static void prepareMLIRKernelWithoutWrapper(mlir::OwningOpRef<mlir::ModuleOp>& m
     // A set of default passes that lower any input IR to LLVM
     PassManager pm(module->getContext());
 
-#if 0  // TODO: if TPP is available
+#ifdef TPP_MLIR // If TPP is available
 
     tpp::DefaultPipelineOptions defPipelineOpts{defGpuBackend};
     pm.addPass(tpp::createDefaultPipeline(defPipelineOpts));

--- a/src/common/transformations/src/transformations/mlir/convert.cpp
+++ b/src/common/transformations/src/transformations/mlir/convert.cpp
@@ -55,6 +55,14 @@
 #include "mlir/Target/LLVMIR/Dialect/All.h"
 #include "mlir/Target/LLVMIR/Export.h"
 #include "mlir/Target/LLVMIR/ModuleTranslation.h"
+
+#ifdef TPP_MLIR // If TPP is available
+#include "TPP/Dialect/Check/CheckDialect.h"
+#include "TPP/Dialect/Perf/PerfDialect.h"
+#include "TPP/Dialect/Xsmm/XsmmDialect.h"
+#include "TPP/GPU/Utils.h"
+#endif
+
 #include "openvino/core/dimension.hpp"
 #include "openvino/core/rt_info.hpp"
 #include "openvino/pass/pattern/op/wrap_type.hpp"
@@ -334,16 +342,24 @@ MLIRContext* get_shared_mlir_context() {
         llvm::InitializeNativeTarget();
         llvm::InitializeNativeTargetAsmPrinter();
 
-        // Initialize GPU-related LLVM machinery
-        // tpp::initializeGpuTargets();
+        std::cerr << "[ DEBUG ] Using TPP_MLIR: ";
+        #if TPP_MLIR
+            // Initialize GPU-related LLVM machinery
+            tpp::initializeGpuTargets();
+            std::cerr << "YES\n";
+        #else
+            std::cerr << "NO\n";
+        #endif
 
         // Add the following to include *all* MLIR Core dialects, or selectively
         // include what you need like above. You only need to register dialects that
         // will be *parsed* by the tool, not the one generated
         DialectRegistry registry;
-        // registry.insert<mlir::xsmm::XsmmDialect>();
-        // registry.insert<mlir::check::CheckDialect>();
-        // registry.insert<mlir::perf::PerfDialect>();
+        #if TPP_MLIR
+            registry.insert<mlir::xsmm::XsmmDialect>();
+            registry.insert<mlir::check::CheckDialect>();
+            registry.insert<mlir::perf::PerfDialect>();
+        #endif
 
         registerAllDialects(registry);
         registerAllExtensions(registry);

--- a/src/common/transformations/src/transformations/mlir/convert.cpp
+++ b/src/common/transformations/src/transformations/mlir/convert.cpp
@@ -56,8 +56,11 @@
 #include "openvino/pass/pattern/op/wrap_type.hpp"
 #include "transformations_visibility.hpp"
 
-using namespace mlir;
+#ifdef TPP_MLIR // If TPP is available
+#include "TPP/PassBundles.h"
+#endif
 
+using namespace mlir;
 
 static void prepareMLIRKernelWithoutWrapper(mlir::OwningOpRef<mlir::ModuleOp>& module) {
     // A set of default passes that lower any input IR to LLVM
@@ -65,7 +68,7 @@ static void prepareMLIRKernelWithoutWrapper(mlir::OwningOpRef<mlir::ModuleOp>& m
 
 #ifdef TPP_MLIR // If TPP is available
 
-    tpp::DefaultPipelineOptions defPipelineOpts{defGpuBackend};
+    tpp::DefaultPipelineOptions defPipelineOpts{};
     pm.addPass(tpp::createDefaultPipeline(defPipelineOpts));
 
 #else  // Simplified default lowering to LLVM from LLVM tests

--- a/src/common/transformations/src/transformations/mlir/mlir_op.cpp
+++ b/src/common/transformations/src/transformations/mlir/mlir_op.cpp
@@ -54,11 +54,7 @@
 #include "mlir/Target/LLVMIR/ModuleTranslation.h"
 
 #ifdef TPP_MLIR // If TPP is available
-#include "TPP/Dialect/Check/CheckDialect.h"
-#include "TPP/Dialect/Perf/PerfDialect.h"
-#include "TPP/Dialect/Xsmm/XsmmDialect.h"
-#include "TPP/GPU/Utils.h"
-#include "TPP/Passes.h"
+#include "TPP/PassBundles.h"
 #endif
 
 namespace {

--- a/src/common/transformations/src/transformations/mlir/mlir_op.cpp
+++ b/src/common/transformations/src/transformations/mlir/mlir_op.cpp
@@ -72,7 +72,7 @@ void prepareMLIRKernelWithoutWrapper(mlir::OwningOpRef<mlir::ModuleOp>& module) 
     // A set of default passes that lower any input IR to LLVM
     PassManager pm(module->getContext());
 
-#if TPP_MLIR && false  // FIXME: Still cannot enable it: undefined reference to mlir::createConvertOpenMPToLLVMPass(), mlir::createParallelLoopToGpuPass() etc.
+#if TPP_MLIR
 
     tpp::DefaultPipelineOptions defPipelineOpts;
     pm.addPass(tpp::createDefaultPipeline(defPipelineOpts));

--- a/src/common/transformations/src/transformations/mlir/mlir_op.cpp
+++ b/src/common/transformations/src/transformations/mlir/mlir_op.cpp
@@ -53,6 +53,14 @@
 #include "mlir/Target/LLVMIR/Export.h"
 #include "mlir/Target/LLVMIR/ModuleTranslation.h"
 
+#ifdef TPP_MLIR // If TPP is available
+#include "TPP/Dialect/Check/CheckDialect.h"
+#include "TPP/Dialect/Perf/PerfDialect.h"
+#include "TPP/Dialect/Xsmm/XsmmDialect.h"
+#include "TPP/GPU/Utils.h"
+#include "TPP/Passes.h"
+#endif
+
 namespace {
 
 using namespace mlir;
@@ -64,9 +72,9 @@ void prepareMLIRKernelWithoutWrapper(mlir::OwningOpRef<mlir::ModuleOp>& module) 
     // A set of default passes that lower any input IR to LLVM
     PassManager pm(module->getContext());
 
-#if 0  // TODO: if TPP is available
+#if TPP_MLIR && false  // FIXME: Still cannot enable it: undefined reference to mlir::createConvertOpenMPToLLVMPass(), mlir::createParallelLoopToGpuPass() etc.
 
-    tpp::DefaultPipelineOptions defPipelineOpts{defGpuBackend};
+    tpp::DefaultPipelineOptions defPipelineOpts;
     pm.addPass(tpp::createDefaultPipeline(defPipelineOpts));
 
 #else  // Simplified default lowering to LLVM from LLVM tests

--- a/src/common/transformations/src/transformations/mlir/mlir_op.cpp
+++ b/src/common/transformations/src/transformations/mlir/mlir_op.cpp
@@ -55,6 +55,7 @@
 
 #ifdef TPP_MLIR // If TPP is available
 #include "TPP/PassBundles.h"
+#include "TPP/Passes.h"
 #endif
 
 namespace {

--- a/src/plugins/intel_npu/tools/compile_tool/CMakeLists.txt
+++ b/src/plugins/intel_npu/tools/compile_tool/CMakeLists.txt
@@ -39,6 +39,9 @@ if(CMAKE_COMPILER_IS_GNUCXX OR OV_COMPILER_IS_CLANG)
     ov_add_compiler_flags(-Wno-missing-declarations)
 endif()
 
+# Adds TPP-MLIR if needed
+enable_tpp_mlir(${TARGET_NAME})
+
 #
 # Install
 #

--- a/src/plugins/intel_npu/tools/compile_tool/CMakeLists.txt
+++ b/src/plugins/intel_npu/tools/compile_tool/CMakeLists.txt
@@ -39,8 +39,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR OV_COMPILER_IS_CLANG)
     ov_add_compiler_flags(-Wno-missing-declarations)
 endif()
 
-# Adds TPP-MLIR if needed
-enable_tpp_mlir(${TARGET_NAME})
 
 #
 # Install


### PR DESCRIPTION
Based on https://github.com/rengolin/openvino/tree/enable-tpp-mlir. Add include directories to `transformations` and link dependencies to openvino library only.