### PR TITLE
Match and lower ov::Relu

### DIFF
--- a/src/common/transformations/src/transformations/mlir/convert_common.cpp
+++ b/src/common/transformations/src/transformations/mlir/convert_common.cpp
@@ -128,5 +128,42 @@ Location createLocation(MLIRContext* ctx, NodePtr node) {
     return createLayerLocation(ctx, node->get_friendly_name(), node->get_type_name());
 }
 
+bool elementwise_no_broadcast_predicate_impl(const ov::Output<ov::Node>& output, ov::element::Type type) {
+    if (output.get_element_type() != type) {
+        return false;
+    }
+    // Check if implicit broadcast is possible, reject in this case
+    // Relies on symbolic information -- register SymbolicPropagation before applying this pattern
+    auto inputs = output.get_node_shared_ptr()->inputs();
+    auto output_shape = output.get_partial_shape();
+    if (output_shape.rank().is_dynamic()) {
+        return false;
+    }
+    if (std::any_of(inputs.begin(), inputs.end(), [&](const ov::Input<ov::Node>& input) {
+            auto input_shape = input.get_partial_shape();
+            return input_shape.rank().is_dynamic() ||
+                   output_shape.rank().get_length() != input_shape.rank().get_length();
+        })) {
+        return false;
+    }
+
+    if (std::any_of(inputs.begin(), inputs.end(), [&](const ov::Input<ov::Node>& input) {
+            for (size_t i = 0; i < output_shape.size(); ++i) {
+                auto input_shape = input.get_partial_shape();
+                if (output_shape[i] != input_shape[i])
+                    return true;
+                if (output_shape[i].is_static() && input_shape[i].is_static())
+                    continue;
+                if (!ov::symbol::are_equal(output_shape[i].get_symbol(), input_shape[i].get_symbol()))
+                    return true;
+            }
+            return false;
+        })) {
+        return false;
+    }
+
+    return true;
+}
+
 } // namespace mlir
 } // namespace ov

--- a/src/common/transformations/src/transformations/mlir/convert_common.hpp
+++ b/src/common/transformations/src/transformations/mlir/convert_common.hpp
@@ -30,6 +30,13 @@ RankedTensorType importTensor(MLIRContext* ctx,
 
 Location createLocation(MLIRContext* ctx, NodePtr node);
 
+bool elementwise_no_broadcast_predicate_impl(const ov::Output<ov::Node>& output, ov::element::Type type);
+
+template <ov::element::Type_t type>
+bool elementwise_no_broadcast_predicate(const ov::Output<ov::Node>& output) {
+    return elementwise_no_broadcast_predicate_impl(output, type);
+}
+
 // Borrowed it from TPP-MLIR. FIXME: Do we have a better upstreamed alternative?
 template <typename T>
 mlir::arith::ConstantOp getConstant(OpBuilder &builder, const ov::element::Type& precision, T value) {

--- a/src/common/transformations/src/transformations/mlir/op/relu.cpp
+++ b/src/common/transformations/src/transformations/mlir/op/relu.cpp
@@ -1,0 +1,59 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Linalg/Passes.h"
+
+#include <openvino/op/relu.hpp>
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+
+#include "relu.hpp"
+#include "../convert_common.hpp"
+
+namespace {
+
+using namespace ov::mlir;
+
+struct ConvertRelu {
+    void operator()(ConversionContext& context, NodePtr node) {
+        auto loc = createLocation(context.context, node);
+        auto& builder = context.builder();
+        // TODO: Support broadcasts
+        const auto input = context.getInputs(node)[0];
+        const auto ov_output_element_type = node->get_output_element_type(0);
+        const auto ov_output_shape = node->get_output_partial_shape(0);
+        auto outType = importTensor(context.context, ov_output_shape, ov_output_element_type);
+        // Named unary ops directly overwrite data in `outs` buffer so, there is no need to provide non-empty
+        // destination at the tensor-level.
+        // Use `tensor.empty` to avoid temporary buffer allocation and memcpy after bufferization.
+        llvm::SmallVector<Value> dynamicSizes;
+        for (auto [idx, dim] : llvm::enumerate(outType.getShape())) {
+            if (!mlir::ShapedType::isDynamic(dim))
+                continue;
+            auto dimSize = builder.create<tensor::DimOp>(loc, input, idx);
+            dynamicSizes.push_back(dimSize);
+        }
+        auto empty = builder.create<tensor::EmptyOp>(loc, outType, dynamicSizes);
+        auto zero = getConstant(builder, ov_output_element_type, 0);
+        auto fill = builder.create<linalg::FillOp>(loc, mlir::ValueRange{zero}, mlir::ValueRange{empty});
+        auto relu =
+            builder.create<linalg::MaxOp>(loc, mlir::ValueRange{input, fill.getResult(0)}, mlir::ValueRange{empty});
+        context.addOutputs(node, relu);
+    }
+};
+
+}  // namespace
+
+namespace ov {
+namespace mlir {
+
+using namespace ov::pass::pattern;
+using namespace ov::op;
+
+ReluPattern::ReluPattern()
+    : MarkPattern(wrap_type<v0::Relu>({any_input()}, elementwise_no_broadcast_predicate<ov::element::f32>),
+                  ConvertRelu()) {}
+
+}  // namespace mlir
+}  // namespace ov

--- a/src/common/transformations/src/transformations/mlir/op/relu.hpp
+++ b/src/common/transformations/src/transformations/mlir/op/relu.hpp
@@ -1,0 +1,23 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/Value.h"
+
+#include "../conversion_context.hpp"
+
+namespace ov {
+namespace mlir {
+
+class ReluPattern : public MarkPattern {
+public:
+    OPENVINO_RTTI("ReluPattern", "0");
+    ReluPattern();
+};
+
+}  // namespace mlir
+}  // namespace ov


### PR DESCRIPTION
Adds ReLU op matcher and lowering to MLIR named Linalg ops.
Also, adds buffer deallocation passes to prevent memory leaks when temporary buffers are created.

Example with ReLU:
```python
import torch
import torch.nn as nn
import openvino as ov

# Define a synthetic model
class LinearModel(nn.Module):
    def __init__(self, input_size, output_size):
        super(LinearModel, self).__init__()
        self.model = nn.Sequential(
			nn.Linear(input_size, output_size),
			nn.ReLU(),
		)
    def forward(self, a):
        return self.model(a)

# Create an instance of the model
input_size = 10
output_size = 5
model = LinearModel(input_size, output_size)
# Generate random weights
model.model[0].weight.data.normal_(0, 0.01)
model.model[0].bias.data.fill_(0.01)

input_data = torch.tensor(range(1, 10*10+1)).to(torch.float32).view(10, 10)

with torch.no_grad():
    reference = model(input_data)
    print('Reference:\n', reference)

ov_model = ov.convert_model(model, example_input=input_data)

# expect lots of debug output with MLIR fragments before and after lowering in this call:
ov_compiled = ov.compile_model(ov_model, 'CPU')

tested = ov_compiled(input_data)[0]
print('Tested:\n', tested)
diff = reference - tested
print('Reference - Tested:\n', diff)
```