### PR TITLE
Fix missing return in Partitioner::run_on_model

### DIFF
--- a/src/common/transformations/src/transformations/mlir/convert.cpp
+++ b/src/common/transformations/src/transformations/mlir/convert.cpp
@@ -272,6 +272,7 @@ public:
             tracker.add_node(node, get_subgraph_mark(node));
         }
         tracker.finalize();
+        return true;
     }
 };
 


### PR DESCRIPTION
Fixes "double free or corruption" in Relase/RelWithDebInfo build types.