### PR TITLE
Pass XSMM runner lib to MLIR execution engine

### DIFF
--- a/cmake/tpp-mlir.cmake
+++ b/cmake/tpp-mlir.cmake
@@ -27,7 +27,11 @@ if (TPP_MLIR_DIR)
             tpp_xsmm_runner_utils
         )
     function(add_tpp_mlir_includes target)
-        target_include_directories(${target} PRIVATE ${TPP_MLIR_DIR}/../include ${TPP_MLIR_DIR}/include)
+        target_include_directories(${target}
+                PRIVATE
+                    ${TPP_MLIR_DIR}/../include
+                    ${TPP_MLIR_DIR}/include
+                    ${TPP_MLIR_DIR}/../runtime)
     endfunction()
     function(add_tpp_mlir_libs target)
         target_link_directories(${target} PRIVATE ${TPP_MLIR_DIR}/lib)


### PR DESCRIPTION
Manually finds and passes XSMM runner library to the MLIR JIT engine to resolve missing TPP xsmm_* symbols when executing from Python.

Works only for Linux currently.

Tested with:
```python
import torch
import torch.nn as nn
import openvino as ov

# Define a synthetic model
class LinearModel(nn.Module):
    def __init__(self, input_size, output_size):
        super(LinearModel, self).__init__()
        self.model = nn.Sequential(
            nn.Linear(input_size, output_size),
            nn.ReLU(),
        )
    def forward(self, a):
        return self.model(a)

# Create an instance of the model
input_size = 1024
output_size = 128
model = LinearModel(input_size, output_size)
# Generate random weights
model.model[0].weight.data.normal_(0, 0.01)
model.model[0].bias.data.fill_(0.01)

input_data = torch.tensor(range(1, input_size*output_size+1)).to(torch.float32)\
    .view(output_size, input_size)

with torch.no_grad():
    reference = model(input_data)
    print('Reference:\n', reference)

# Dynamic shapes
# ov_model = ov.convert_model(model, example_input=input_data)
# Static shapes
ov_model = ov.convert_model(model, input=(ov.Shape([output_size, input_size]), ov.Type.f32))

# expect lots of debug output with MLIR fragments before and after lowering in this call:
ov_compiled = ov.compile_model(ov_model, 'CPU')

tested = ov_compiled(input_data)[0]
print('Tested:\n', tested)
diff = reference - tested
print('Reference - Tested:\n', diff)
```