### PR TITLE
Broadcast support for elementwise ops

### DIFF
--- a/src/common/transformations/src/transformations/mlir/conversion_context.cpp
+++ b/src/common/transformations/src/transformations/mlir/conversion_context.cpp
@@ -58,6 +58,16 @@ void ConversionContext::set_convertor(NodePtr node, const Convertor& convertor) 
     node->get_rt_info()[rt_info_convertor()] = as_any;
 }
 
+Value ConversionContext::get_dimension_value(const Dimension& d) {
+    auto symbol = d.get_symbol();
+    assert(symbol);
+    symbol = ov::symbol::ancestor_of(symbol);
+    // Suppose all dimensions are known and the map is populated
+    // FIXME: Add dimensions on demand to avoid unnecessary operations in the produced MLIR
+    assert(dimension_map.count(symbol));
+    return dimension_map.at(symbol);
+}
+
 
 
 const std::string& subgraph_mark() {

--- a/src/common/transformations/src/transformations/mlir/conversion_context.cpp
+++ b/src/common/transformations/src/transformations/mlir/conversion_context.cpp
@@ -68,6 +68,15 @@ Value ConversionContext::get_dimension_value(const Dimension& d) {
     return dimension_map.at(symbol);
 }
 
+SmallVector<Value> ConversionContext::get_dynamic_dimension_values (const PartialShape& shape) {
+    SmallVector<Value> dims;
+    for (const auto& dim: shape) {
+        if (dim.is_dynamic()) {
+            dims.push_back(get_dimension_value(dim));
+        }
+    }
+    return dims;
+}
 
 
 const std::string& subgraph_mark() {

--- a/src/common/transformations/src/transformations/mlir/conversion_context.hpp
+++ b/src/common/transformations/src/transformations/mlir/conversion_context.hpp
@@ -50,6 +50,8 @@ public:
     void convert(NodePtr node);
 
     Value get_dimension_value(const Dimension& d);
+
+    SmallVector<Value> get_dynamic_dimension_values (const PartialShape& shape);
 };
 
 

--- a/src/common/transformations/src/transformations/mlir/conversion_context.hpp
+++ b/src/common/transformations/src/transformations/mlir/conversion_context.hpp
@@ -11,6 +11,7 @@
 #include "mlir/IR/Builders.h"
 
 #include "typedefs.hpp"
+#include "convert_common.hpp"
 
 namespace ov {
 namespace mlir {
@@ -20,6 +21,7 @@ using ::mlir::MLIRContext;
 using ::mlir::OpBuilder;
 using ::mlir::Operation;
 using ::mlir::SmallVector;
+using ::mlir::ValueRange;
 
 class ConversionContext {
     static std::string rt_info_convertor ();
@@ -32,6 +34,7 @@ public:
     mlir::MLIRContext* context;
     mlir::OpBuilder* block_builder;
     NodeOutputMap nodeOutputMap;
+    std::map<SymbolPtr, Value> dimension_map;
 
     ConversionContext(mlir::MLIRContext* context, mlir::OpBuilder* block_builder);
 
@@ -45,6 +48,8 @@ public:
     static void set_convertor(NodePtr node, const Convertor& convertor);
 
     void convert(NodePtr node);
+
+    Value get_dimension_value(const Dimension& d);
 };
 
 

--- a/src/common/transformations/src/transformations/mlir/convert.cpp
+++ b/src/common/transformations/src/transformations/mlir/convert.cpp
@@ -277,10 +277,10 @@ void injectMLIR(std::shared_ptr<ov::Model> model, MLIRContext* context) {
     using namespace ov::op;
     manager.set_per_pass_validation(false);
     manager.register_pass<ov::pass::SymbolicPropagation>();
-    manager.register_pass<BinaryEltwisePattern<v1::Add, linalg::AddOp>>();
-    manager.register_pass<BinaryEltwisePattern<v1::Subtract, linalg::SubOp>>();
-    manager.register_pass<BinaryEltwisePattern<v1::Multiply, linalg::MulOp>>();
-    manager.register_pass<BinaryEltwisePattern<v1::Divide, linalg::DivOp>>();
+    manager.register_pass<BinaryEltwisePattern<v1::Add, linalg::AddOp>>(ov::element::f32);
+    manager.register_pass<BinaryEltwisePattern<v1::Subtract, linalg::SubOp>>(ov::element::f32);
+    manager.register_pass<BinaryEltwisePattern<v1::Multiply, linalg::MulOp>>(ov::element::f32);
+    manager.register_pass<BinaryEltwisePattern<v1::Divide, linalg::DivOp>>(ov::element::f32);
     manager.register_pass<ReluPattern>();
     manager.register_pass<MatMulPattern>();
     manager.register_pass<Partitioner>(context);

--- a/src/common/transformations/src/transformations/mlir/convert.cpp
+++ b/src/common/transformations/src/transformations/mlir/convert.cpp
@@ -68,6 +68,7 @@
 #include "mlir_op.hpp"
 #include "op/matmul.hpp"
 #include "op/relu.hpp"
+#include "op/binary_eltwise.hpp"
 #include "openvino/core/dimension.hpp"
 #include "openvino/core/rt_info.hpp"
 #include "openvino/core/symbol.hpp"
@@ -107,30 +108,6 @@ SmallVector<mlir::Type> get_types_for_values(mlir::MLIRContext* context, const o
     return types;
 }
 
-template <typename TargetOp>
-struct ConvertBinary {
-    void operator()(ConversionContext& context, NodePtr node) {
-        auto loc = createLocation(context.context, node);
-        auto& builder = context.builder();
-        // TODO: Support broadcasts
-        const auto inputs = context.getInputs(node);
-        auto outType = cast<mlir::ShapedType>(inputs[0].getType());
-        // Named binary ops directly overwrite data in `outs` buffer so, there is no need to provide non-empty
-        // destination at the tensor-level.
-        // Use `tensor.empty` to avoid temporary buffer allocation and memcpy after bufferization.
-        llvm::SmallVector<Value> dynamicSizes;
-        for (auto [idx, dim] : llvm::enumerate(outType.getShape())) {
-            if (!mlir::ShapedType::isDynamic(dim))
-                continue;
-            auto dimSize = builder.create<tensor::DimOp>(loc, inputs[0], idx);
-            dynamicSizes.push_back(dimSize);
-        }
-        auto empty = builder.create<tensor::EmptyOp>(loc, outType, dynamicSizes);
-        auto op = builder.create<TargetOp>(loc, mlir::ValueRange{inputs[0], inputs[1]}, mlir::ValueRange{empty});
-        context.addOutputs(node, op);
-    }
-};
-
 
 mlir::OwningOpRef<mlir::ModuleOp> ngraph_to_mlir(MLIRContext* context,
                                                  const ov::OutputVector& inputs,
@@ -159,6 +136,24 @@ mlir::OwningOpRef<mlir::ModuleOp> ngraph_to_mlir(MLIRContext* context,
         auto loc = createLocation(context, inputs[i].get_node_shared_ptr());
         auto tensor = block_builder.create<bufferization::ToTensorOp>(loc, funcInputVal, /*restrict = */ true);
         conversion_context.nodeOutputMap.emplace(inputs[i], tensor);
+
+        // FIXME: Avoid pre-population of dimension_map, take dimension values only if needed
+        auto input_shape = inputs[i].get_partial_shape();
+        auto input_rank = input_shape.rank();
+        if(input_rank.is_static()) {
+            for(size_t j = 0; j < input_rank.get_length(); ++j) {
+                auto dim = input_shape[j];
+                if(dim.is_dynamic()) {
+                    auto symbol = dim.get_symbol();
+                    assert(symbol);
+                    symbol = ov::symbol::ancestor_of(symbol);
+                    if(dim.is_dynamic() && !conversion_context.dimension_map.count(symbol)) {
+                        auto dimSize = block_builder.create<tensor::DimOp>(loc, tensor, j);
+                        conversion_context.dimension_map[symbol] = dimSize;
+                    }
+                }
+            }
+        }
     }
 
     for (size_t i = 0; i < nodes.size(); ++i) {
@@ -276,21 +271,16 @@ public:
     }
 };
 
-template <typename Op>
-NodePtr elementwise_f32_binary_no_broadcast() {
-    using namespace ov::pass::pattern;
-    return wrap_type<Op>({any_input(), any_input()}, elementwise_no_broadcast_predicate<ov::element::f32>);
-}
 
 void injectMLIR(std::shared_ptr<ov::Model> model, MLIRContext* context) {
     ov::pass::Manager manager;
     using namespace ov::op;
     manager.set_per_pass_validation(false);
     manager.register_pass<ov::pass::SymbolicPropagation>();
-    manager.register_pass<MarkPattern>(elementwise_f32_binary_no_broadcast<v1::Add>(), ConvertBinary<linalg::AddOp>());
-    manager.register_pass<MarkPattern>(elementwise_f32_binary_no_broadcast<v1::Subtract>(), ConvertBinary<linalg::SubOp>());
-    manager.register_pass<MarkPattern>(elementwise_f32_binary_no_broadcast<v1::Multiply>(), ConvertBinary<linalg::MulOp>());
-    manager.register_pass<MarkPattern>(elementwise_f32_binary_no_broadcast<v1::Divide>(), ConvertBinary<linalg::DivOp>());
+    manager.register_pass<BinaryEltwisePattern<v1::Add, linalg::AddOp>>();
+    manager.register_pass<BinaryEltwisePattern<v1::Subtract, linalg::SubOp>>();
+    manager.register_pass<BinaryEltwisePattern<v1::Multiply, linalg::MulOp>>();
+    manager.register_pass<BinaryEltwisePattern<v1::Divide, linalg::DivOp>>();
     manager.register_pass<ReluPattern>();
     manager.register_pass<MatMulPattern>();
     manager.register_pass<Partitioner>(context);

--- a/src/common/transformations/src/transformations/mlir/convert_common.cpp
+++ b/src/common/transformations/src/transformations/mlir/convert_common.cpp
@@ -209,28 +209,46 @@ bool statically_broadcastable(const PartialShape& from, const PartialShape& to) 
     return true;
 }
 
-std::vector<int64_t> broadcast_dimensions(const PartialShape& from, const PartialShape& to) {
-    assert(statically_broadcastable(from, to));
+BroadcastDimensions broadcast_dimensions(const PartialShape& src, const PartialShape& dst) {
+    assert(statically_broadcastable(src, dst));
 
-    auto from_rank = from.rank().get_length();
-    auto to_rank = to.rank().get_length();
+    auto src_rank = src.rank().get_length();
+    auto dst_rank = dst.rank().get_length();
+    auto offset = dst_rank - src_rank;
 
-    auto offset = to_rank - from_rank;
-    std::vector<int64_t> dimensions;
+    BroadcastDimensions result;
+    auto& [collapse_groups, dimensions] = result;
+    ReassociationIndices group;
+    bool group_bonded = false;  // true if `group` has a non-brodcasted dimension
 
-    for(size_t i = 0; i < to_rank; ++i) {
-        if (i < offset) {
-            dimensions.push_back(i);
+    size_t dst_i = 0;  // dimension index in the `dst` shape
+    for(; dst_i < offset; ++dst_i) {
+        dimensions.push_back(dst_i);
+    }
+    for(; dst_i < dst_rank; ++dst_i) {
+        auto src_i = dst_i - offset;
+        auto src_d = src[src_i];
+        auto dst_d = dst[dst_i];
+        if(has_broadcast(src_d, dst_d)) {
+            dimensions.push_back(dst_i);
         } else {
-            auto d_from = from[i - offset];
-            auto d_to = to[i];
-            if(has_broadcast(d_from, d_to)) {
-                dimensions.push_back(i);
+            if(group_bonded) {
+                collapse_groups.emplace_back(group);
+                group = ReassociationIndices();
+            } else {
+                group_bonded = true;
             }
         }
+        group.push_back(src_i);
     }
 
-    return dimensions;
+    if(group_bonded && !group.empty()) {
+        collapse_groups.emplace_back(group);
+    }
+
+    assert(dst_rank - dimensions.size() == collapse_groups.size());
+
+    return result;
 }
 
 bool symbol_ancestor_less (SymbolPtr x, SymbolPtr y) {

--- a/src/common/transformations/src/transformations/mlir/convert_common.cpp
+++ b/src/common/transformations/src/transformations/mlir/convert_common.cpp
@@ -132,29 +132,21 @@ bool elementwise_no_broadcast_predicate_impl(const ov::Output<ov::Node>& output,
     if (output.get_element_type() != type) {
         return false;
     }
+    if (has_dynamic_rank(output.get_node_shared_ptr())) {
+        return false;
+    }
     // Check if implicit broadcast is possible, reject in this case
     // Relies on symbolic information -- register SymbolicPropagation before applying this pattern
     auto inputs = output.get_node_shared_ptr()->inputs();
     auto output_shape = output.get_partial_shape();
-    if (output_shape.rank().is_dynamic()) {
-        return false;
-    }
-    if (std::any_of(inputs.begin(), inputs.end(), [&](const ov::Input<ov::Node>& input) {
-            auto input_shape = input.get_partial_shape();
-            return input_shape.rank().is_dynamic() ||
-                   output_shape.rank().get_length() != input_shape.rank().get_length();
-        })) {
-        return false;
-    }
 
     if (std::any_of(inputs.begin(), inputs.end(), [&](const ov::Input<ov::Node>& input) {
+            auto input_shape = input.get_partial_shape();
+            if(output_shape.rank().get_length() != input_shape.rank().get_length()) {
+                return true;
+            }
             for (size_t i = 0; i < output_shape.size(); ++i) {
-                auto input_shape = input.get_partial_shape();
-                if (output_shape[i] != input_shape[i])
-                    return true;
-                if (output_shape[i].is_static() && input_shape[i].is_static())
-                    continue;
-                if (!ov::symbol::are_equal(output_shape[i].get_symbol(), input_shape[i].get_symbol()))
+                if(!are_equal_dimensions(input_shape[i], output_shape[i]))
                     return true;
             }
             return false;
@@ -163,6 +155,86 @@ bool elementwise_no_broadcast_predicate_impl(const ov::Output<ov::Node>& output,
     }
 
     return true;
+}
+
+bool has_dynamic_rank(NodePtr node) {
+    auto inputs = node->inputs();
+    auto outputs = node->outputs();
+    if (std::any_of(inputs.begin(), inputs.end(), [&](const ov::Input<ov::Node>& input) {
+            return input.get_partial_shape().rank().is_dynamic();
+        })) {
+        return true;
+    }
+    if (std::any_of(outputs.begin(), outputs.end(), [&](const ov::Output<ov::Node>& output) {
+            return output.get_partial_shape().rank().is_dynamic();
+        })) {
+        return true;
+    }
+    return false;
+}
+
+bool are_equal_dimensions(Dimension d1, Dimension d2) {
+    return
+        d1.is_static() && d2.is_static() && d1 == d2
+        ||
+        ov::symbol::are_equal(d1.get_symbol(), d2.get_symbol());
+}
+
+bool has_broadcast(Dimension from, Dimension to) {
+    return from.is_static() && from.get_length() == 1 && !are_equal_dimensions(from, to);
+}
+
+bool statically_broadcastable(const PartialShape& from, const PartialShape& to) {
+    if(from.rank().is_dynamic() || to.rank().is_dynamic()) { // FIXME: `from` can has dynamic rank
+        return false;
+    }
+
+    auto from_rank = from.rank().get_length();
+    auto to_rank = to.rank().get_length();
+
+    if(from_rank > to_rank) { // such cases shouldn't be allowed to this function, but kept to make the function generic
+        return false;
+    }
+
+    auto offset = to_rank - from_rank;
+    for(size_t i = 0; i < from_rank; ++i) {
+        auto d_from = from[i];
+        auto d_to = to[offset + i];
+        if(!are_equal_dimensions(d_from, d_to) && !has_broadcast(d_from, d_to)) {
+            // cannot deduce neither dimensions broadcast nor dimensions equality
+            return false;
+        }
+    }
+
+    return true;
+}
+
+std::vector<int64_t> broadcast_dimensions(const PartialShape& from, const PartialShape& to) {
+    assert(statically_broadcastable(from, to));
+
+    auto from_rank = from.rank().get_length();
+    auto to_rank = to.rank().get_length();
+
+    auto offset = to_rank - from_rank;
+    std::vector<int64_t> dimensions;
+
+    for(size_t i = 0; i < to_rank; ++i) {
+        if (i < offset) {
+            dimensions.push_back(i);
+        } else {
+            auto d_from = from[i - offset];
+            auto d_to = to[i];
+            if(has_broadcast(d_from, d_to)) {
+                dimensions.push_back(i);
+            }
+        }
+    }
+
+    return dimensions;
+}
+
+bool symbol_ancestor_less (SymbolPtr x, SymbolPtr y) {
+    return ov::symbol::ancestor_of(x) < ov::symbol::ancestor_of(y);
 }
 
 } // namespace mlir

--- a/src/common/transformations/src/transformations/mlir/convert_common.hpp
+++ b/src/common/transformations/src/transformations/mlir/convert_common.hpp
@@ -9,6 +9,7 @@
 #include "mlir/IR/MLIRContext.h"
 #include "mlir/IR/Location.h"
 #include "mlir/Dialect/Arith/IR/Arith.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
 
 #include "typedefs.hpp"
 
@@ -60,7 +61,8 @@ bool has_broadcast(Dimension from, Dimension to);
 
 bool statically_broadcastable(const PartialShape& from, const PartialShape& to);
 
-std::vector<int64_t> broadcast_dimensions(const PartialShape& from, const PartialShape& to);
+using BroadcastDimensions = std::tuple<SmallVector<ReassociationIndices>, SmallVector<int64_t>>;
+BroadcastDimensions broadcast_dimensions(const PartialShape& from, const PartialShape& to);
 
 bool symbol_ancestor_less (SymbolPtr x, SymbolPtr y);
 

--- a/src/common/transformations/src/transformations/mlir/convert_common.hpp
+++ b/src/common/transformations/src/transformations/mlir/convert_common.hpp
@@ -52,5 +52,17 @@ mlir::arith::ConstantOp getConstant(OpBuilder &builder, const ov::element::Type&
     return builder.create<arith::ConstantOp>(unkLoc, type, attr);
 }
 
+bool has_dynamic_rank(NodePtr node);
+
+bool are_equal_dimensions(Dimension d1, Dimension d2);
+
+bool has_broadcast(Dimension from, Dimension to);
+
+bool statically_broadcastable(const PartialShape& from, const PartialShape& to);
+
+std::vector<int64_t> broadcast_dimensions(const PartialShape& from, const PartialShape& to);
+
+bool symbol_ancestor_less (SymbolPtr x, SymbolPtr y);
+
 } // namespace mlir
 } // namespace ov

--- a/src/common/transformations/src/transformations/mlir/op/binary_eltwise.cpp
+++ b/src/common/transformations/src/transformations/mlir/op/binary_eltwise.cpp
@@ -1,0 +1,122 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Dialect/Tensor/IR/Tensor.h"
+#include "mlir/Dialect/Linalg/Passes.h"
+
+#include <openvino/op/relu.hpp>
+#include "openvino/pass/pattern/op/wrap_type.hpp"
+
+#include "binary_eltwise.hpp"
+
+namespace {
+
+using namespace ov;
+using namespace ov::mlir;
+using ::mlir::ValueRange;
+
+class ConvertBinaryEltwise {
+
+    BinaryEltwisePatternBase::Builder m_op_builder;
+
+public:
+
+    ConvertBinaryEltwise(BinaryEltwisePatternBase::Builder op_builder) : m_op_builder(op_builder) {}
+
+    void operator()(ConversionContext& context, NodePtr node) {
+        auto loc = createLocation(context.context, node);
+        auto& builder = context.builder();
+        const auto inputs = context.getInputs(node);
+        const auto ov_output_element_type = node->get_output_element_type(0);
+        const auto ov_output_shape = node->get_output_partial_shape(0);
+        auto outType = importTensor(context.context, ov_output_shape, ov_output_element_type);
+        const int output_rank = ov_output_shape.rank().get_length();
+
+        SmallVector<Value> dynamicSizes;
+        for (auto [idx, dim] : llvm::enumerate(ov_output_shape)) {
+            if (!dim.is_dynamic())
+                continue;
+            dynamicSizes.push_back(context.get_dimension_value(dim));
+        }
+
+        SmallVector<Value> broadcasted_inputs;
+        for(size_t i = 0; i < inputs.size(); ++i) {
+            auto dimensions = broadcast_dimensions(node->get_input_partial_shape(i), ov_output_shape);
+            if(!dimensions.empty()) {
+                // FIXME: Find a way to avoid dimension squeezing before applying linalg.broadcast
+
+                // Step 1: Squeeze input shape to eliminate broadcasted dimensions
+                SmallVector<ReassociationIndices, 6> squeeze_map;
+                ReassociationIndices ri_cur;
+                size_t output_idx = 0; // index in ov_output_shape
+                bool group_open = true;
+                for(auto [_, dim]: llvm::enumerate(dimensions)) {
+                    for(; output_idx < dim; ++output_idx) {
+                        if(!ri_cur.empty() && !group_open) {
+                            squeeze_map.emplace_back(ri_cur);
+                            ri_cur = ReassociationIndices();
+                        }
+                        ri_cur.push_back(output_idx);
+                        group_open = false;
+                    }
+                    assert(dim == output_idx);
+                    ri_cur.push_back(dim);
+                    ++output_idx;
+                }
+                for(; output_idx < output_rank; ++output_idx) {
+                    if(group_open) {
+                        ri_cur.push_back(output_idx);
+                        squeeze_map.push_back(ri_cur);
+                        group_open = false;
+                    } else {
+                        squeeze_map.push_back({output_idx});
+                    }
+                }
+
+                auto squeezed = builder.create<tensor::CollapseShapeOp>(loc, inputs[i], squeeze_map);
+
+                // Step 2: Broadcast squeezed shape to the target shape
+                auto empty = builder.create<tensor::EmptyOp>(loc, outType, dynamicSizes);
+                auto op = builder.create<linalg::BroadcastOp>(loc, squeezed, empty, dimensions);
+                broadcasted_inputs.push_back(op.getResult()[0]);
+            } else {
+                broadcasted_inputs.push_back(inputs[i]);
+            }
+        }
+
+        auto empty = builder.create<tensor::EmptyOp>(loc, outType, dynamicSizes);
+        auto op = m_op_builder(builder, loc, ValueRange(broadcasted_inputs), ValueRange{empty});
+        context.addOutputs(node, op);
+    }
+};
+
+}  // namespace
+
+namespace ov {
+namespace mlir {
+
+using namespace ov::pass::pattern;
+
+BinaryEltwisePatternBase::BinaryEltwisePatternBase(NodeTypeInfo wrapped_type, Builder op_builder)
+    : MarkPattern(
+        std::make_shared<pass::pattern::op::WrapType>(
+            wrapped_type,
+            [](const Output<Node>& output) {
+                auto node = output.get_node_shared_ptr();
+                for(const auto& input: node->inputs()) {
+                    if(!statically_broadcastable(input.get_partial_shape(), output.get_partial_shape())) {
+                        return false;
+                    }
+                }
+                return true;
+            },
+            OutputVector{any_input(), any_input()}),
+        ConvertBinaryEltwise(op_builder))
+    {}
+
+}  // namespace mlir
+}  // namespace ov

--- a/src/common/transformations/src/transformations/mlir/op/binary_eltwise.cpp
+++ b/src/common/transformations/src/transformations/mlir/op/binary_eltwise.cpp
@@ -36,51 +36,17 @@ public:
         auto outType = importTensor(context.context, ov_output_shape, ov_output_element_type);
         const int output_rank = ov_output_shape.rank().get_length();
 
-        SmallVector<Value> dynamicSizes;
-        for (auto [idx, dim] : llvm::enumerate(ov_output_shape)) {
-            if (!dim.is_dynamic())
-                continue;
-            dynamicSizes.push_back(context.get_dimension_value(dim));
-        }
+        SmallVector<Value> dynamic_dimensions = context.get_dynamic_dimension_values(ov_output_shape);
 
         SmallVector<Value> broadcasted_inputs;
         for(size_t i = 0; i < inputs.size(); ++i) {
-            auto dimensions = broadcast_dimensions(node->get_input_partial_shape(i), ov_output_shape);
+            auto [collapse_groups, dimensions] = broadcast_dimensions(node->get_input_partial_shape(i), ov_output_shape);
             if(!dimensions.empty()) {
                 // FIXME: Find a way to avoid dimension squeezing before applying linalg.broadcast
-
                 // Step 1: Squeeze input shape to eliminate broadcasted dimensions
-                SmallVector<ReassociationIndices, 6> squeeze_map;
-                ReassociationIndices ri_cur;
-                size_t output_idx = 0; // index in ov_output_shape
-                bool group_open = true;
-                for(auto [_, dim]: llvm::enumerate(dimensions)) {
-                    for(; output_idx < dim; ++output_idx) {
-                        if(!ri_cur.empty() && !group_open) {
-                            squeeze_map.emplace_back(ri_cur);
-                            ri_cur = ReassociationIndices();
-                        }
-                        ri_cur.push_back(output_idx);
-                        group_open = false;
-                    }
-                    assert(dim == output_idx);
-                    ri_cur.push_back(dim);
-                    ++output_idx;
-                }
-                for(; output_idx < output_rank; ++output_idx) {
-                    if(group_open) {
-                        ri_cur.push_back(output_idx);
-                        squeeze_map.push_back(ri_cur);
-                        group_open = false;
-                    } else {
-                        squeeze_map.push_back({output_idx});
-                    }
-                }
-
-                auto squeezed = builder.create<tensor::CollapseShapeOp>(loc, inputs[i], squeeze_map);
-
+                auto squeezed = builder.create<tensor::CollapseShapeOp>(loc, inputs[i], collapse_groups);
                 // Step 2: Broadcast squeezed shape to the target shape
-                auto empty = builder.create<tensor::EmptyOp>(loc, outType, dynamicSizes);
+                auto empty = builder.create<tensor::EmptyOp>(loc, outType, dynamic_dimensions);
                 auto op = builder.create<linalg::BroadcastOp>(loc, squeezed, empty, dimensions);
                 broadcasted_inputs.push_back(op.getResult()[0]);
             } else {
@@ -88,7 +54,7 @@ public:
             }
         }
 
-        auto empty = builder.create<tensor::EmptyOp>(loc, outType, dynamicSizes);
+        auto empty = builder.create<tensor::EmptyOp>(loc, outType, dynamic_dimensions);
         auto op = m_op_builder(builder, loc, ValueRange(broadcasted_inputs), ValueRange{empty});
         context.addOutputs(node, op);
     }

--- a/src/common/transformations/src/transformations/mlir/op/binary_eltwise.cpp
+++ b/src/common/transformations/src/transformations/mlir/op/binary_eltwise.cpp
@@ -67,11 +67,14 @@ namespace mlir {
 
 using namespace ov::pass::pattern;
 
-BinaryEltwisePatternBase::BinaryEltwisePatternBase(NodeTypeInfo wrapped_type, Builder op_builder)
+BinaryEltwisePatternBase::BinaryEltwisePatternBase(NodeTypeInfo wrapped_type, Builder op_builder, const std::set<element::Type>& element_types)
     : MarkPattern(
         std::make_shared<pass::pattern::op::WrapType>(
             wrapped_type,
-            [](const Output<Node>& output) {
+            [element_types](const Output<Node>& output) {
+                if(!element_types.empty() && !element_types.count(output.get_element_type())) {
+                    return false;
+                }
                 auto node = output.get_node_shared_ptr();
                 for(const auto& input: node->inputs()) {
                     if(!statically_broadcastable(input.get_partial_shape(), output.get_partial_shape())) {

--- a/src/common/transformations/src/transformations/mlir/op/binary_eltwise.hpp
+++ b/src/common/transformations/src/transformations/mlir/op/binary_eltwise.hpp
@@ -1,0 +1,36 @@
+// Copyright (C) 2018-2024 Intel Corporation
+// SPDX-License-Identifier: Apache-2.0
+//
+
+#pragma once
+
+#include "../conversion_context.hpp"
+
+namespace ov {
+namespace mlir {
+
+class BinaryEltwisePatternBase : public MarkPattern {
+public:
+    using Builder = std::function<Operation*(OpBuilder&, ::mlir::Location, ValueRange, ValueRange)>;
+
+    OPENVINO_RTTI("BinaryEltwisePatternBase", "0");
+    BinaryEltwisePatternBase(NodeTypeInfo wrapped_type, Builder op_builder);
+};
+
+
+template <typename OVOp, typename LinalgOp>
+class BinaryEltwisePattern : public BinaryEltwisePatternBase {
+public:
+    BinaryEltwisePattern () :
+        BinaryEltwisePatternBase(
+            OVOp::get_type_info_static(),
+            [](OpBuilder& builder, ::mlir::Location loc, ValueRange ins, ValueRange outs) -> Operation* {
+                return builder.create<LinalgOp>(loc, ins, outs);
+            })
+    {}
+};
+
+
+}  // namespace mlir
+}  // namespace ov
+

--- a/src/common/transformations/src/transformations/mlir/op/binary_eltwise.hpp
+++ b/src/common/transformations/src/transformations/mlir/op/binary_eltwise.hpp
@@ -14,19 +14,25 @@ public:
     using Builder = std::function<Operation*(OpBuilder&, ::mlir::Location, ValueRange, ValueRange)>;
 
     OPENVINO_RTTI("BinaryEltwisePatternBase", "0");
-    BinaryEltwisePatternBase(NodeTypeInfo wrapped_type, Builder op_builder);
+    BinaryEltwisePatternBase(NodeTypeInfo wrapped_type, Builder op_builder, const std::set<element::Type>& element_types = {});
 };
 
 
 template <typename OVOp, typename LinalgOp>
 class BinaryEltwisePattern : public BinaryEltwisePatternBase {
 public:
-    BinaryEltwisePattern () :
+    // Allow conversion for given `element_types` only, except case when `element_types` is empty which means no restrictions on types, everything is allowed.
+    BinaryEltwisePattern (const std::set<element::Type>& element_types = {}) :
         BinaryEltwisePatternBase(
             OVOp::get_type_info_static(),
             [](OpBuilder& builder, ::mlir::Location loc, ValueRange ins, ValueRange outs) -> Operation* {
                 return builder.create<LinalgOp>(loc, ins, outs);
-            })
+            },
+            element_types)
+    {}
+
+    BinaryEltwisePattern (const element::Type& element_type) :
+        BinaryEltwisePattern(std::set<element::Type>{element_type})
     {}
 };
 


### PR DESCRIPTION
TODO:
- [ ] On-demand taking of dynamic dims as values instead of pre-initialization with all dynamic dims. (_Will be covered with a further PR, should have no negative impact if we are lowering to linalg as it always requires taking all dynamic dimensions to construct the outputs. Plus I would expect dead code elimination from the MLIR pipeline_.)
- [x] Element type restriction for the new binary eltwise convertor
- [x] Fix incorrect shape collapsing in case of broadcast with unaligned ranks
- [x] Reuse dynamic dimensions map in MatMul conversion.

Now the entire graph (except tensor constants) from https://github.com/slyalin/openvino/pull/146#issuecomment-2245172158 is converted as a single MLIR function:
```mlir
module @fragment_name {
  func.func @entry(%arg0: memref<?x?xf32>, %arg1: memref<1x1xf32>, %arg2: memref<128x1024xf32>, %arg3: memref<1x128xf32>, %arg4: memref<?x128xf32>) {
    %0 = bufferization.to_tensor %arg0 restrict : memref<?x?xf32>
    %c0 = arith.constant 0 : index
    %dim = tensor.dim %0, %c0 : tensor<?x?xf32>
    %c1 = arith.constant 1 : index
    %dim_0 = tensor.dim %0, %c1 : tensor<?x?xf32>
    %1 = bufferization.to_tensor %arg1 restrict : memref<1x1xf32>
    %2 = bufferization.to_tensor %arg2 restrict : memref<128x1024xf32>
    %3 = bufferization.to_tensor %arg3 restrict : memref<1x128xf32>
    %4 = tensor.empty(%dim, %dim_0) : tensor<?x?xf32>
    %5 = linalg.mul ins(%0, %0 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%4 : tensor<?x?xf32>) -> tensor<?x?xf32>
    %collapsed = tensor.collapse_shape %1 [] : tensor<1x1xf32> into tensor<f32>
    %6 = tensor.empty(%dim, %dim_0) : tensor<?x?xf32>
    %broadcasted = linalg.broadcast ins(%collapsed : tensor<f32>) outs(%6 : tensor<?x?xf32>) dimensions = [0, 1] 
    %7 = tensor.empty(%dim, %dim_0) : tensor<?x?xf32>
    %8 = linalg.add ins(%5, %broadcasted : tensor<?x?xf32>, tensor<?x?xf32>) outs(%7 : tensor<?x?xf32>) -> tensor<?x?xf32>
    %9 = tensor.empty(%dim, %dim_0) : tensor<?x?xf32>
    %10 = linalg.sub ins(%0, %8 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%9 : tensor<?x?xf32>) -> tensor<?x?xf32>
    %11 = tensor.empty(%dim, %dim_0) : tensor<?x?xf32>
    %12 = linalg.add ins(%0, %0 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%11 : tensor<?x?xf32>) -> tensor<?x?xf32>
    %13 = tensor.empty(%dim, %dim_0) : tensor<?x?xf32>
    %14 = linalg.mul ins(%12, %10 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%13 : tensor<?x?xf32>) -> tensor<?x?xf32>
    %15 = tensor.empty(%dim, %dim_0) : tensor<?x?xf32>
    %16 = linalg.div ins(%14, %0 : tensor<?x?xf32>, tensor<?x?xf32>) outs(%15 : tensor<?x?xf32>) -> tensor<?x?xf32>
    %17 = tensor.empty(%dim) : tensor<?x128xf32>
    %cst = arith.constant 0.000000e+00 : f32
    %18 = linalg.fill ins(%cst : f32) outs(%17 : tensor<?x128xf32>) -> tensor<?x128xf32>
    %19 = linalg.matmul_transpose_b ins(%16, %2 : tensor<?x?xf32>, tensor<128x1024xf32>) outs(%18 : tensor<?x128xf32>) -> tensor<?x128xf32>
    %collapsed_1 = tensor.collapse_shape %3 [[0, 1]] : tensor<1x128xf32> into tensor<128xf32>
    %20 = tensor.empty(%dim) : tensor<?x128xf32>
    %broadcasted_2 = linalg.broadcast ins(%collapsed_1 : tensor<128xf32>) outs(%20 : tensor<?x128xf32>) dimensions = [0] 
    %21 = tensor.empty(%dim) : tensor<?x128xf32>
    %22 = linalg.add ins(%19, %broadcasted_2 : tensor<?x128xf32>, tensor<?x128xf32>) outs(%21 : tensor<?x128xf32>) -> tensor<?x128xf32>
    bufferization.materialize_in_destination %22 in restrict writable %arg4 : (tensor<?x128xf32>, memref<?x128xf32>) -> ()
    return
  }
}
```