### PR TITLE
Disable MatMul conversion for not supported cases to avoid crashing

### DIFF
--- a/src/common/transformations/src/transformations/mlir/op/matmul.cpp
+++ b/src/common/transformations/src/transformations/mlir/op/matmul.cpp
@@ -18,12 +18,6 @@ using namespace ov::mlir;
 
 struct ConvertMatMul {
     void operator()(ConversionContext& context, NodePtr node) {
-        auto matmul_node = std::dynamic_pointer_cast<ov::op::v0::MatMul>(node);
-        assert(matmul_node);
-
-        // FIXME: current code limitation
-        assert(!matmul_node->get_transpose_a() && matmul_node->get_transpose_b());
-
         auto loc = createLocation(context.context, node);
         auto& builder = context.builder();
         // TODO: Support broadcasts
@@ -50,7 +44,12 @@ using namespace ov::pass::pattern;
 using namespace ov::op;
 
 MatMulPattern::MatMulPattern() : MarkPattern(
-    wrap_type<v0::MatMul>({any_input(), any_input()}),
+    wrap_type<v0::MatMul>({any_input(), any_input()}, [](const Output<Node>& output) {
+        auto matmul_node = std::dynamic_pointer_cast<v0::MatMul>(output.get_node_shared_ptr());
+        assert(matmul_node);
+        // FIXME: current code limitation
+        return !matmul_node->get_transpose_a() && matmul_node->get_transpose_b();
+    }),
     ConvertMatMul()) {
     }
 

--- a/src/common/transformations/src/transformations/mlir/op/matmul.cpp
+++ b/src/common/transformations/src/transformations/mlir/op/matmul.cpp
@@ -45,10 +45,14 @@ using namespace ov::op;
 
 MatMulPattern::MatMulPattern() : MarkPattern(
     wrap_type<v0::MatMul>({any_input(), any_input()}, [](const Output<Node>& output) {
-        auto matmul_node = std::dynamic_pointer_cast<v0::MatMul>(output.get_node_shared_ptr());
-        assert(matmul_node);
+        auto node = std::dynamic_pointer_cast<v0::MatMul>(output.get_node_shared_ptr());
+        assert(node);
         // FIXME: current code limitation
-        return !matmul_node->get_transpose_a() && matmul_node->get_transpose_b();
+        return
+            !has_dynamic_rank(node) &&
+            !node->get_transpose_a() && node->get_transpose_b() &&
+            node->get_input_partial_shape(0).rank().get_length() == 2 &&
+            node->get_input_partial_shape(1).rank().get_length() == 2;
     }),
     ConvertMatMul()) {
     }


### PR DESCRIPTION
Fixes failures in PyTorch layer tests for `addmm` and `linear`.