### PR TITLE
More matmul variants

### DIFF
--- a/src/common/transformations/src/transformations/mlir/op/matmul.cpp
+++ b/src/common/transformations/src/transformations/mlir/op/matmul.cpp
@@ -29,8 +29,24 @@ struct ConvertMatMul {
         auto empty = builder.create<tensor::EmptyOp>(loc, outType, dynamic_dimensions);
         auto zero = getConstant(builder, ov_output_element_type, 0);
         auto fill = builder.create<linalg::FillOp>(loc, mlir::ValueRange{zero}, mlir::ValueRange{empty});
-        // TODO: Add other variants of transpose_a/transpose_b
-        auto matmul = builder.create<linalg::MatmulTransposeBOp>(loc, mlir::ValueRange{inputs[0], inputs[1]}, mlir::ValueRange{fill.getResult(0)});
+
+        mlir::ValueRange ins{inputs[0], inputs[1]};
+        mlir::ValueRange outs{fill.getResult(0)};
+
+        auto matmul_node = std::dynamic_pointer_cast<ov::op::v0::MatMul>(node);
+        assert(matmul_node);
+        bool isTransposedA = matmul_node->get_transpose_a();
+        bool isTransposedB = matmul_node->get_transpose_b();
+        assert(!(isTransposedA && isTransposedB));
+        Operation* matmul;
+        if (isTransposedA) {
+            matmul = builder.create<linalg::MatmulTransposeAOp>(loc, ins, outs);
+        } else if (isTransposedB) {
+            matmul = builder.create<linalg::MatmulTransposeBOp>(loc, ins, outs);
+        } else {
+            matmul = builder.create<linalg::MatmulOp>(loc, ins, outs);
+        }
+
         context.addOutputs(node, matmul);
     }
 };
@@ -48,11 +64,9 @@ MatMulPattern::MatMulPattern() : MarkPattern(
         auto node = std::dynamic_pointer_cast<v0::MatMul>(output.get_node_shared_ptr());
         assert(node);
         // FIXME: current code limitation
-        return
-            !has_dynamic_rank(node) &&
-            !node->get_transpose_a() && node->get_transpose_b() &&
-            node->get_input_partial_shape(0).rank().get_length() == 2 &&
-            node->get_input_partial_shape(1).rank().get_length() == 2;
+        return !has_dynamic_rank(node) && !(node->get_transpose_a() && node->get_transpose_b()) &&
+               node->get_input_partial_shape(0).rank().get_length() == 2 &&
+               node->get_input_partial_shape(1).rank().get_length() == 2;
     }),
     ConvertMatMul()) {
     }

--- a/src/common/transformations/src/transformations/mlir/op/matmul.cpp
+++ b/src/common/transformations/src/transformations/mlir/op/matmul.cpp
@@ -30,14 +30,15 @@ struct ConvertMatMul {
         auto zero = getConstant(builder, ov_output_element_type, 0);
         auto fill = builder.create<linalg::FillOp>(loc, mlir::ValueRange{zero}, mlir::ValueRange{empty});
 
-        mlir::ValueRange ins{inputs[0], inputs[1]};
-        mlir::ValueRange outs{fill.getResult(0)};
+        mlir::SmallVector<Value, 2> ins{inputs[0], inputs[1]};
+        mlir::SmallVector<Value, 1> outs{fill.getResult(0)};
 
         auto matmul_node = std::dynamic_pointer_cast<ov::op::v0::MatMul>(node);
         assert(matmul_node);
         bool isTransposedA = matmul_node->get_transpose_a();
         bool isTransposedB = matmul_node->get_transpose_b();
         assert(!(isTransposedA && isTransposedB));
+
         Operation* matmul;
         if (isTransposedA) {
             matmul = builder.create<linalg::MatmulTransposeAOp>(loc, ins, outs);


### PR DESCRIPTION
Adds support for `linalg.matmul` and `linalg.matmul_tranpose_a`.

Tested with:
```python
import torch
import torch.nn as nn
import openvino as ov


# Define a synthetic model
class MatmulVariants(nn.Module):
    def __init__(self, sizes_mnk, type=None):
        super(MatmulVariants, self).__init__()
        m = sizes_mnk[0]
        n = sizes_mnk[1]
        k = sizes_mnk[2]
        self.weight_b = torch.empty((k, n), dtype=type).data.normal_(0, 0.01)
        self.bias = torch.empty((m, n), dtype=type).data.fill_(0.01)
        self.relu = nn.ReLU()
    def forward(self, a, b):
        # matmul
        mm = torch.matmul(a, b)
        add1 = torch.add(mm, self.bias)
        out1 = self.relu(add1)
        # matmul_transpose_b
        mmt = torch.matmul(a, self.weight_b)
        add2 = torch.add(mmt, self.bias)
        out2 = self.relu(add2)
        return out1 - out2

# Create an instance of the model
input_size = 1024
output_size = 128
model = MatmulVariants([output_size, output_size, input_size])

input_data_A = torch.tensor(range(1, input_size*output_size+1)).to(torch.float32)\
    .view(output_size, input_size)
input_data_B = torch.tensor(range(1, input_size*output_size+1)).to(torch.float32)\
    .view(input_size, output_size)

with torch.no_grad():
    reference = model(input_data_A, input_data_B)
    print('Reference:\n', reference)

# Dynamic shapes
# ov_model = ov.convert_model(model, example_input=input_data)
# Static shapes
ov_model = ov.convert_model(model,
                            input=[(ov.PartialShape([output_size, input_size]), ov.Type.f32),
                                   (ov.PartialShape([input_size, output_size]), ov.Type.f32)])
# ov.save_model(ov_model, "simple_model.mm.xml")

# expect lots of debug output with MLIR fragments before and after lowering in this call:
ov_compiled = ov.compile_model(ov_model, 'CPU')

tested = ov_compiled([input_data_A, input_data_B])[0]
print('Tested:\n', tested)
diff = reference - tested
print('Reference - Tested:\n', diff)
```