### PR TITLE
Environment variables to control MLIR execution

### DIFF
--- a/src/common/transformations/src/transformations/mlir/convert.cpp
+++ b/src/common/transformations/src/transformations/mlir/convert.cpp
@@ -204,8 +204,9 @@ NodePtr ngraph_to_mlir_op(MLIRContext* context, SubgraphPtr subgraph, bool tpp_m
                 if(0 == input_map.count(symbol)) {
                     input_map[symbol] = Index(i, j);
                 } else {
-                    std::cerr << "[ DEBUG ] Lost equality constraint for dimensions in output " << input << "\n"
-                              << "          If the constraint is violated in runtime it will result in the undefined behaviour.\n";
+                    OPENVINO_MLIR_DEBUG_PRINT(
+                        "[ DEBUG ] Lost equality constraint for dimensions in output " << input << ".\n" <<
+                        "          If the constraint is violated in runtime it will result in the undefined behaviour.\n");
                 }
             }
         }
@@ -265,7 +266,7 @@ public:
         SubgraphTracker tracker([this](SubgraphPtr subgraph) {
                 auto mlir_op = ngraph_to_mlir_op(context, subgraph, tpp_mlir_enabled);
                 replace_subgraph(subgraph, mlir_op);
-                std::cerr << "Created MLIR op: " << mlir_op << "\n";
+                OPENVINO_MLIR_DEBUG_PRINT("Created MLIR op: " << mlir_op << "\n");
             }
         );
         for(auto node: model->get_ordered_ops()) {
@@ -303,7 +304,7 @@ MLIRContext* get_shared_mlir_context(bool tpp_mlir_enabled_current) {
 
     if(context) {
         if(tpp_mlir_enabled_current != tpp_mlir_enabled) {
-            std::cerr << "[ DEBUG ] Switched TPP mode, reinitialize MLIR context\n";
+            OPENVINO_MLIR_DEBUG_PRINT("[ DEBUG ] Switched TPP mode, reinitialize MLIR context\n");
             tpp_mlir_enabled = tpp_mlir_enabled_current;
             context.reset();
         }
@@ -315,15 +316,15 @@ MLIRContext* get_shared_mlir_context(bool tpp_mlir_enabled_current) {
         llvm::InitializeNativeTarget();
         llvm::InitializeNativeTargetAsmPrinter();
 
-        std::cerr << "[ DEBUG ] Using TPP_MLIR: ";
+        OPENVINO_MLIR_DEBUG_PRINT("[ DEBUG ] Using TPP_MLIR: ");
         if(tpp_mlir_enabled) {
-            std::cerr << "YES\n";
+            OPENVINO_MLIR_DEBUG_PRINT("YES\n");
             // Initialize GPU-related LLVM machinery
             #ifdef TPP_MLIR
                 tpp::initializeGpuTargets();
             #endif
         } else {
-            std::cerr << "NO\n";
+            OPENVINO_MLIR_DEBUG_PRINT("NO\n");
         }
 
         // Add the following to include *all* MLIR Core dialects, or selectively

--- a/src/common/transformations/src/transformations/mlir/convert.cpp
+++ b/src/common/transformations/src/transformations/mlir/convert.cpp
@@ -14,6 +14,7 @@
 #include <openvino/pass/graph_rewrite.hpp>
 #include <openvino/pass/manager.hpp>
 #include <openvino/pass/pattern/op/wrap_type.hpp>
+#include <openvino/util/env_util.hpp>
 #include <unordered_map>
 
 // TODO: Prune unused headers -- it's hard to understand needed ones
@@ -187,7 +188,7 @@ mlir::OwningOpRef<mlir::ModuleOp> ngraph_to_mlir(MLIRContext* context,
 
 
 // This pass converts a group of nodes into a single MLIROp
-NodePtr ngraph_to_mlir_op(MLIRContext* context, SubgraphPtr subgraph) {
+NodePtr ngraph_to_mlir_op(MLIRContext* context, SubgraphPtr subgraph, bool tpp_mlir_enabled) {
     mlir::OwningOpRef<mlir::ModuleOp> module = ngraph_to_mlir(context, subgraph->inputs, subgraph->nodes, subgraph->outputs);
 
     const auto& inputs = subgraph->inputs;
@@ -230,7 +231,7 @@ NodePtr ngraph_to_mlir_op(MLIRContext* context, SubgraphPtr subgraph) {
     }
     return std::make_shared<MLIROp>(
         subgraph->inputs,
-        std::make_shared<MLIREvaluate>(std::move(module)),
+        std::make_shared<MLIREvaluate>(std::move(module), tpp_mlir_enabled),
         output_types,
         output_map
     );
@@ -251,14 +252,18 @@ void replace_subgraph(SubgraphPtr subgraph, NodePtr node) {
 
 class Partitioner : public ov::pass::ModelPass {
     MLIRContext* context;
+    bool tpp_mlir_enabled;
 public:
     OPENVINO_RTTI("Partitioner");
 
-    Partitioner(MLIRContext* context) : context(context) {}
+    Partitioner(MLIRContext* context, bool tpp_mlir_enabled) :
+        context(context),
+        tpp_mlir_enabled(tpp_mlir_enabled)
+    {}
 
     bool run_on_model(const std::shared_ptr<ov::Model>& model) override {
         SubgraphTracker tracker([this](SubgraphPtr subgraph) {
-                auto mlir_op = ngraph_to_mlir_op(context, subgraph);
+                auto mlir_op = ngraph_to_mlir_op(context, subgraph, tpp_mlir_enabled);
                 replace_subgraph(subgraph, mlir_op);
                 std::cerr << "Created MLIR op: " << mlir_op << "\n";
             }
@@ -272,7 +277,7 @@ public:
 };
 
 
-void injectMLIR(std::shared_ptr<ov::Model> model, MLIRContext* context) {
+void injectMLIR(std::shared_ptr<ov::Model> model, MLIRContext* context, bool tpp_mlir_enabled) {
     ov::pass::Manager manager;
     using namespace ov::op;
     manager.set_per_pass_validation(false);
@@ -283,17 +288,26 @@ void injectMLIR(std::shared_ptr<ov::Model> model, MLIRContext* context) {
     manager.register_pass<BinaryEltwisePattern<v1::Divide, linalg::DivOp>>(ov::element::f32);
     manager.register_pass<ReluPattern>();
     manager.register_pass<MatMulPattern>();
-    manager.register_pass<Partitioner>(context);
+    manager.register_pass<Partitioner>(context, tpp_mlir_enabled);
     manager.run_passes(model);
     model->validate_nodes_and_infer_types();
 }
 
 
-MLIRContext* get_shared_mlir_context() {
+MLIRContext* get_shared_mlir_context(bool tpp_mlir_enabled_current) {
     // Gives MLIRContext instance shared for entire OV process and initialized once upon the initial request
     // FIXME: Bind with OpenVINO lifetime in the sutable class instead of dirty tricking with static lifetime
 
     static std::shared_ptr<MLIRContext> context;
+    static bool tpp_mlir_enabled = tpp_mlir_enabled_current;
+
+    if(context) {
+        if(tpp_mlir_enabled_current != tpp_mlir_enabled) {
+            std::cerr << "[ DEBUG ] Switched TPP mode, reinitialize MLIR context\n";
+            tpp_mlir_enabled = tpp_mlir_enabled_current;
+            context.reset();
+        }
+    }
 
     if (!context) {
 
@@ -302,23 +316,27 @@ MLIRContext* get_shared_mlir_context() {
         llvm::InitializeNativeTargetAsmPrinter();
 
         std::cerr << "[ DEBUG ] Using TPP_MLIR: ";
-        #if TPP_MLIR
-            // Initialize GPU-related LLVM machinery
-            tpp::initializeGpuTargets();
+        if(tpp_mlir_enabled) {
             std::cerr << "YES\n";
-        #else
+            // Initialize GPU-related LLVM machinery
+            #ifdef TPP_MLIR
+                tpp::initializeGpuTargets();
+            #endif
+        } else {
             std::cerr << "NO\n";
-        #endif
+        }
 
         // Add the following to include *all* MLIR Core dialects, or selectively
         // include what you need like above. You only need to register dialects that
         // will be *parsed* by the tool, not the one generated
         DialectRegistry registry;
-        #if TPP_MLIR
-            registry.insert<mlir::xsmm::XsmmDialect>();
-            registry.insert<mlir::check::CheckDialect>();
-            registry.insert<mlir::perf::PerfDialect>();
-        #endif
+        if(tpp_mlir_enabled) {
+            #ifdef TPP_MLIR
+                registry.insert<mlir::xsmm::XsmmDialect>();
+                registry.insert<mlir::check::CheckDialect>();
+                registry.insert<mlir::perf::PerfDialect>();
+            #endif
+        }
 
         registerAllDialects(registry);
         registerAllExtensions(registry);
@@ -339,5 +357,20 @@ MLIRContext* get_shared_mlir_context() {
 } // namespace
 
 void ov::pass::transformMLIR(std::shared_ptr<ov::Model> model) {
-    injectMLIR(model, get_shared_mlir_context());
+    if(util::getenv_bool("OV_MLIR", true)) {
+        bool tpp_mlir_default =
+            #ifdef TPP_MLIR
+                true;
+            #else
+                false;
+            #endif
+        bool tpp_mlir_enabled = util::getenv_bool("OV_MLIR_TPP", tpp_mlir_default);
+        #ifndef TPP_MLIR
+            OPENVINO_ASSERT(!tpp_mlir_enabled,
+                "[ ERROR ] OpenVINO wasn't compiled with TPP_MLIR support, "
+                "but OV_MLIR_TPP environment variable is set to enable it.");
+        #endif
+
+        injectMLIR(model, get_shared_mlir_context(tpp_mlir_enabled), tpp_mlir_enabled);
+    }
 }

--- a/src/common/transformations/src/transformations/mlir/convert_common.cpp
+++ b/src/common/transformations/src/transformations/mlir/convert_common.cpp
@@ -4,6 +4,9 @@
 
 #include "convert_common.hpp"
 
+#include <openvino/util/env_util.hpp>
+
+
 namespace {
 
 using namespace mlir;
@@ -58,6 +61,9 @@ IntegerType getBool8Type(MLIRContext* ctx) {
 namespace ov {
 namespace mlir {
 
+bool is_debug() {
+    util::getenv_bool("OV_MLIR_DEBUG", false);
+}
 
 Location createLayerLocation(MLIRContext* ctx, const std::string& layerName, const std::string& layerType) {
     const auto layerNameAttr = StringAttr::get(ctx, layerName);

--- a/src/common/transformations/src/transformations/mlir/convert_common.hpp
+++ b/src/common/transformations/src/transformations/mlir/convert_common.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <iostream>
+
 #include "mlir/IR/BuiltinAttributes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/MLIRContext.h"
@@ -16,6 +18,11 @@
 
 namespace ov {
 namespace mlir {
+
+bool is_debug();
+
+#define OPENVINO_MLIR_DEBUG(X) do if(::ov::mlir::is_debug()) { X; } while(false)
+#define OPENVINO_MLIR_DEBUG_PRINT(X) do if(::ov::mlir::is_debug()) { ::std::cerr << X; } while(false)
 
 using namespace ::mlir;
 

--- a/src/common/transformations/src/transformations/mlir/mlir_op.cpp
+++ b/src/common/transformations/src/transformations/mlir/mlir_op.cpp
@@ -221,7 +221,7 @@ struct MemRef {
             assert(byte_strides[i] % element_size == 0);
             // TODO: handle case when stride is not aligned (restrict at OV API level)
             strides[i] = byte_strides[i] / element_size;
-            //std::cout << "stride [" << i << "] = " << strides[i] << "\n";
+            //std::cerr << "stride [" << i << "] = " << strides[i] << "\n";
         }
     }
 
@@ -254,21 +254,22 @@ using namespace ::mlir;
 
 MLIREvaluate::MLIREvaluate(OwningOpRef<mlir::ModuleOp> _module, bool tpp_mlir_enabled) :
     module(std::move(_module)) {
-    if (true) {
-        std::cerr << "[ DEBUG ] Source MLIR:\n";
-        std::cerr << "-----------------------------------------\n";
-        module->dump();
-        std::cerr << "-----------------------------------------\n";
-    }
+
+    OPENVINO_MLIR_DEBUG_PRINT(
+        "[ DEBUG ] Source MLIR:\n"
+        "-----------------------------------------\n");
+    OPENVINO_MLIR_DEBUG(module->dump());
+    OPENVINO_MLIR_DEBUG_PRINT(
+        "-----------------------------------------\n");
 
     prepareMLIRKernelWithoutWrapper(module, tpp_mlir_enabled);
 
-    if (true) {
-        std::cerr << "[ DEBUG ] Target LLVM:\n";
-        std::cerr << "-----------------------------------------\n";
-        module->dump();
-        std::cerr << "-----------------------------------------\n";
-    }
+    OPENVINO_MLIR_DEBUG_PRINT(
+        "[ DEBUG ] Target LLVM:\n"
+        "-----------------------------------------\n");
+    OPENVINO_MLIR_DEBUG(module->dump());
+    OPENVINO_MLIR_DEBUG_PRINT(
+        "-----------------------------------------\n");
 
     auto optPipeline = mlir::makeOptimizingTransformer(2,
                                                         /*sizeLevel=*/0,  // FIXME: HARDCODED
@@ -321,6 +322,7 @@ bool MLIROp::evaluate(ov::TensorVector& outputs, const ov::TensorVector& inputs)
         memref_args.push_back(MemRef(inputs[i]));
     }
     for (size_t i = 0; i < outputs.size(); ++i) {
+        // TODO: Optimize by adding all dimensions to dimensions_map, not only dynamic
         Shape target;
         PartialShape expected = get_output_partial_shape(i);
         for(size_t j = 0; j < expected.size(); ++j) {

--- a/src/common/transformations/src/transformations/mlir/mlir_op.cpp
+++ b/src/common/transformations/src/transformations/mlir/mlir_op.cpp
@@ -65,77 +65,73 @@ using namespace mlir;
 using NodePtr = std::shared_ptr<ov::Node>;
 using SymbolPtr = std::shared_ptr<ov::Symbol>;
 
-void prepareMLIRKernelWithoutWrapper(mlir::OwningOpRef<mlir::ModuleOp>& module) {
-    // A set of default passes that lower any input IR to LLVM
+void prepareMLIRKernelWithoutWrapper(mlir::OwningOpRef<mlir::ModuleOp>& module, bool tpp_mlir_enabled) {
     PassManager pm(module->getContext());
+    if(tpp_mlir_enabled) {
+        #ifdef TPP_MLIR
+            tpp::DefaultPipelineOptions defPipelineOpts;
+            pm.addPass(tpp::createDefaultPipeline(defPipelineOpts));
+        #endif
+    } else {
+        // Cleanup before bufferization.
+        // Simplifies IR to allow better bufferization.
+        pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+        pm.addNestedPass<func::FuncOp>(createCSEPass());
 
-#if TPP_MLIR
+        // Remove empty tensors to avoid converting them into temporary buffers.
+        pm.addPass(bufferization::createEmptyTensorEliminationPass());
 
-    tpp::DefaultPipelineOptions defPipelineOpts;
-    pm.addPass(tpp::createDefaultPipeline(defPipelineOpts));
+        pm.addPass(bufferization::createOneShotBufferizePass());
+        pm.addNestedPass<func::FuncOp>(bufferization::createFinalizingBufferizePass());
 
-#else  // Simplified default lowering to LLVM from LLVM tests
+        // Cleanup after bufferization - possibly remove redundant copies.
+        pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
+        pm.addNestedPass<func::FuncOp>(createCSEPass());
 
-    // Cleanup before bufferization.
-    // Simplifies IR to allow better bufferization.
-    pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
-    pm.addNestedPass<func::FuncOp>(createCSEPass());
+        // Deallocation pipeline to avoid memory leaks from created temporary buffers.
+        pm.addPass(memref::createExpandReallocPass(/*emitDeallocs=*/false));
+        pm.addPass(createCanonicalizerPass());
+        bufferization::DeallocationOptions deallocOpts;
+        deallocOpts.privateFuncDynamicOwnership = false;
+        pm.addPass(bufferization::createOwnershipBasedBufferDeallocationPass(deallocOpts));
+        pm.addPass(createCanonicalizerPass());
+        pm.addPass(bufferization::createBufferDeallocationSimplificationPass());
+        pm.addPass(bufferization::createLowerDeallocationsPass());
+        pm.addPass(createCSEPass());
+        pm.addPass(createCanonicalizerPass());
 
-    // Remove empty tensors to avoid converting them into temporary buffers.
-    pm.addPass(bufferization::createEmptyTensorEliminationPass());
-
-    pm.addPass(bufferization::createOneShotBufferizePass());
-    pm.addNestedPass<func::FuncOp>(bufferization::createFinalizingBufferizePass());
-
-    // Cleanup after bufferization - possibly remove redundant copies.
-    pm.addNestedPass<func::FuncOp>(createCanonicalizerPass());
-    pm.addNestedPass<func::FuncOp>(createCSEPass());
-
-    // Deallocation pipeline to avoid memory leaks from created temporary buffers.
-    pm.addPass(memref::createExpandReallocPass(/*emitDeallocs=*/false));
-    pm.addPass(createCanonicalizerPass());
-    bufferization::DeallocationOptions deallocOpts;
-    deallocOpts.privateFuncDynamicOwnership = false;
-    pm.addPass(bufferization::createOwnershipBasedBufferDeallocationPass(deallocOpts));
-    pm.addPass(createCanonicalizerPass());
-    pm.addPass(bufferization::createBufferDeallocationSimplificationPass());
-    pm.addPass(bufferization::createLowerDeallocationsPass());
-    pm.addPass(createCSEPass());
-    pm.addPass(createCanonicalizerPass());
-
-    // Blanket-convert any remaining high-level vector ops to loops if any remain.
-    pm.addNestedPass<func::FuncOp>(createConvertVectorToSCFPass());
-    // pm.addNestedPass<func::FuncOp>(createLinalgGeneralizeNamedOpsPass());
-    //  Blanket-convert any remaining linalg ops to loops if any remain.
-    pm.addNestedPass<func::FuncOp>(createConvertLinalgToLoopsPass());
-    // Blanket-convert any remaining affine ops if any remain.
-    pm.addPass(createLowerAffinePass());
-    // Convert SCF to CF (always needed).
-    pm.addPass(createConvertSCFToCFPass());
-    // Sprinkle some cleanups.
-    pm.addPass(createCanonicalizerPass());
-    pm.addPass(createCSEPass());
-    // Blanket-convert any remaining linalg ops to LLVM if any remain.
-    // pm.addPass(createConvertLinalgToLLVMPass());  // no such pass
-    // Convert vector to LLVM (always needed).
-    pm.addPass(createConvertVectorToLLVMPass());
-    // Convert Math to LLVM (always needed).
-    pm.addNestedPass<func::FuncOp>(createConvertMathToLLVMPass());
-    // Expand complicated MemRef operations before lowering them.
-    pm.addPass(memref::createExpandStridedMetadataPass());
-    // The expansion may create affine expressions. Get rid of them.
-    pm.addPass(createLowerAffinePass());
-    // Convert MemRef to LLVM (always needed).
-    // pm.addPass(memref::createExpandOpsPass());
-    pm.addPass(createFinalizeMemRefToLLVMConversionPass());
-    // Convert Func to LLVM (always needed).
-    pm.addPass(createConvertFuncToLLVMPass());
-    // Convert Index to LLVM (always needed).
-    pm.addPass(createConvertIndexToLLVMPass());
-    // Convert remaining unrealized_casts (always needed).
-    pm.addPass(createReconcileUnrealizedCastsPass());
-
-#endif
+        // Blanket-convert any remaining high-level vector ops to loops if any remain.
+        pm.addNestedPass<func::FuncOp>(createConvertVectorToSCFPass());
+        // pm.addNestedPass<func::FuncOp>(createLinalgGeneralizeNamedOpsPass());
+        //  Blanket-convert any remaining linalg ops to loops if any remain.
+        pm.addNestedPass<func::FuncOp>(createConvertLinalgToLoopsPass());
+        // Blanket-convert any remaining affine ops if any remain.
+        pm.addPass(createLowerAffinePass());
+        // Convert SCF to CF (always needed).
+        pm.addPass(createConvertSCFToCFPass());
+        // Sprinkle some cleanups.
+        pm.addPass(createCanonicalizerPass());
+        pm.addPass(createCSEPass());
+        // Blanket-convert any remaining linalg ops to LLVM if any remain.
+        // pm.addPass(createConvertLinalgToLLVMPass());  // no such pass
+        // Convert vector to LLVM (always needed).
+        pm.addPass(createConvertVectorToLLVMPass());
+        // Convert Math to LLVM (always needed).
+        pm.addNestedPass<func::FuncOp>(createConvertMathToLLVMPass());
+        // Expand complicated MemRef operations before lowering them.
+        pm.addPass(memref::createExpandStridedMetadataPass());
+        // The expansion may create affine expressions. Get rid of them.
+        pm.addPass(createLowerAffinePass());
+        // Convert MemRef to LLVM (always needed).
+        // pm.addPass(memref::createExpandOpsPass());
+        pm.addPass(createFinalizeMemRefToLLVMConversionPass());
+        // Convert Func to LLVM (always needed).
+        pm.addPass(createConvertFuncToLLVMPass());
+        // Convert Index to LLVM (always needed).
+        pm.addPass(createConvertIndexToLLVMPass());
+        // Convert remaining unrealized_casts (always needed).
+        pm.addPass(createReconcileUnrealizedCastsPass());
+    }
 
     auto result = pm.run(module.get());
     if (failed(result)) {
@@ -256,7 +252,8 @@ namespace mlir {
 using namespace ::mlir;
 
 
-MLIREvaluate::MLIREvaluate(OwningOpRef<mlir::ModuleOp> _module) : module(std::move(_module)) {
+MLIREvaluate::MLIREvaluate(OwningOpRef<mlir::ModuleOp> _module, bool tpp_mlir_enabled) :
+    module(std::move(_module)) {
     if (true) {
         std::cerr << "[ DEBUG ] Source MLIR:\n";
         std::cerr << "-----------------------------------------\n";
@@ -264,7 +261,7 @@ MLIREvaluate::MLIREvaluate(OwningOpRef<mlir::ModuleOp> _module) : module(std::mo
         std::cerr << "-----------------------------------------\n";
     }
 
-    prepareMLIRKernelWithoutWrapper(module);
+    prepareMLIRKernelWithoutWrapper(module, tpp_mlir_enabled);
 
     if (true) {
         std::cerr << "[ DEBUG ] Target LLVM:\n";

--- a/src/common/transformations/src/transformations/mlir/mlir_op.hpp
+++ b/src/common/transformations/src/transformations/mlir/mlir_op.hpp
@@ -29,7 +29,7 @@ class MLIREvaluate {
 
 public:
 
-    MLIREvaluate(OwningOpRef<ModuleOp> _module);
+    MLIREvaluate(OwningOpRef<ModuleOp> _module, bool tpp_mlir_enabled);
     bool invoke_packed(std::vector<void*>& args);
 };
 

--- a/src/common/transformations/src/transformations/mlir/op/matmul.cpp
+++ b/src/common/transformations/src/transformations/mlir/op/matmul.cpp
@@ -18,12 +18,6 @@ using namespace ov::mlir;
 
 struct ConvertMatMul {
     void operator()(ConversionContext& context, NodePtr node) {
-        auto matmul_node = std::dynamic_pointer_cast<ov::op::v0::MatMul>(node);
-        assert(matmul_node);
-
-        // FIXME: current code limitation
-        assert(!matmul_node->get_transpose_a() && matmul_node->get_transpose_b());
-
         auto loc = createLocation(context.context, node);
         auto& builder = context.builder();
         // TODO: Support broadcasts
@@ -50,7 +44,12 @@ using namespace ov::pass::pattern;
 using namespace ov::op;
 
 MatMulPattern::MatMulPattern() : MarkPattern(
-    wrap_type<v0::MatMul>({any_input(), any_input()}),
+    wrap_type<v0::MatMul>({any_input(), any_input()}, [](const Output<Node>& output) {
+        auto matmul_node = std::dynamic_pointer_cast<v0::MatMul>(output.get_node_shared_ptr());
+        assert(matmul_node);
+        // FIXME: current code limitation
+        return !matmul_node->get_transpose_a() && matmul_node->get_transpose_b();
+    }),
     ConvertMatMul()) {
     }
 

--- a/src/common/transformations/src/transformations/mlir/op/matmul.cpp
+++ b/src/common/transformations/src/transformations/mlir/op/matmul.cpp
@@ -45,10 +45,14 @@ using namespace ov::op;
 
 MatMulPattern::MatMulPattern() : MarkPattern(
     wrap_type<v0::MatMul>({any_input(), any_input()}, [](const Output<Node>& output) {
-        auto matmul_node = std::dynamic_pointer_cast<v0::MatMul>(output.get_node_shared_ptr());
-        assert(matmul_node);
+        auto node = std::dynamic_pointer_cast<v0::MatMul>(output.get_node_shared_ptr());
+        assert(node);
         // FIXME: current code limitation
-        return !matmul_node->get_transpose_a() && matmul_node->get_transpose_b();
+        return
+            !has_dynamic_rank(node) &&
+            !node->get_transpose_a() && node->get_transpose_b() &&
+            node->get_input_partial_shape(0).rank().get_length() == 2 &&
+            node->get_input_partial_shape(1).rank().get_length() == 2;
     }),
     ConvertMatMul()) {
     }


### PR DESCRIPTION
Introducing a few environment variables to control MLIR stack in run-time. All environment variables have the prefix `OV_MLIR_` and are enabled/disabled by setting values `1`, `true`, `ON` and `0`, `false`, `OFF` correspondingly. Values are case insensitive.

- `OV_MLIR`: Enables MLIR stack. When disabled the execution is the same as in vanilla OpenVINO. Default: `ON`.
- `OV_MLIR_TPP`: Enables TPP-MLIR. OpenVINO should be built with TPP-MLIR support to be enabled by this variable. Default: `ON` if built with TPP-MLIR, `OFF` if built without TPP-MLIR. If OpenVINO is built without TPP-MLIR and the variable is set to enable it, a run-time exception will be thrown.
- `OV_MLIR_DEBUG`: Enables debug output in MLIR stack. Default: `OFF`. Earlier it was always enabled, now it should be enabled explicitly.