### PR TITLE
Fix graph partitioner when multiple MLIROp instances go side-by-side

### DIFF
--- a/src/common/transformations/src/transformations/mlir/convert_common.cpp
+++ b/src/common/transformations/src/transformations/mlir/convert_common.cpp
@@ -62,7 +62,7 @@ namespace ov {
 namespace mlir {
 
 bool is_debug() {
-    util::getenv_bool("OV_MLIR_DEBUG", false);
+    return util::getenv_bool("OV_MLIR_DEBUG", false);
 }
 
 Location createLayerLocation(MLIRContext* ctx, const std::string& layerName, const std::string& layerType) {

--- a/src/common/transformations/src/transformations/mlir/subgraph_tracker.cpp
+++ b/src/common/transformations/src/transformations/mlir/subgraph_tracker.cpp
@@ -116,7 +116,11 @@ void SubgraphTracker::set_dependencies(NodePtr node, const Dependencies& depende
 // set/get subgraph id that a give node belongs to
 
 SubgraphID SubgraphTracker::get_subgraph_id(NodePtr node) {
-    auto id = node->get_rt_info().at("__subgraph_id").as<SubgraphID>();
+    const auto& rti = node->get_rt_info();
+    if(!rti.count("__subgraph_id")) {
+        return nullptr;
+    }
+    auto id = rti.at("__subgraph_id").as<SubgraphID>();
     if(id) {
         id = ov::symbol::ancestor_of(id);
     }


### PR DESCRIPTION
Also fixed missing return statement in `is_dubug` function.
It should fix addmm pytorch layer tests (but the final graph form is not what we want to have -- due to ConvertLike ops that break the graph into multiple parts -- will be addressed later).