### PR TITLE
Align MLP sizes with TPP-MLIR benchmarks

### DIFF
--- a/tools/mlir_bench/libxsmm_bench.sh
+++ b/tools/mlir_bench/libxsmm_bench.sh
@@ -36,7 +36,7 @@ if ! [ "$(command -v ${BENCH_RUNNER})" ]; then
   echo "Missing benchmark runner ${BENCH_RUNNER}"
   exit 1
 fi
-if [ ${IS_DYNAMIC} ]; then
+if [ "${IS_DYNAMIC}" ]; then
   echo "Dynamic shapes are not supported by ${BENCH_RUNNER}"
   exit 1
 fi

--- a/tools/mlir_bench/libxsmm_bench.sh
+++ b/tools/mlir_bench/libxsmm_bench.sh
@@ -42,16 +42,16 @@ if [ ${IS_DYNAMIC} ]; then
 fi
 
 # Kernel config.
-INPUT_SIZES=( 1024 2048 4096 8192 )
-OUTPUT_SIZES=( 128 256 512 )
+LAYERS=( 1024 2048 4096 8192 )
+MINI_BATCHES=( 128 256 512 )
 if [ ! "${DATA_TYPE}" ]; then
     DATA_TYPE="f32"
 fi
 
 echo "Result type: GFLOPS"
-for OUT_SIZE in "${OUTPUT_SIZES[@]}"; do
-  echo "MLP - OUT: ${OUT_SIZE} INS: ${INPUT_SIZES[@]}"
-  for IN_SIZE in "${INPUT_SIZES[@]}"; do
+for MB in "${MINI_BATCHES[@]}"; do
+  echo "MLP - MB: ${MB} LAYERS: ${LAYERS[@]}"
+  for LAYER in "${LAYERS[@]}"; do
     # Run benchmark.
     NUM_ITER=10000
     FUSE_TYPE=5
@@ -63,8 +63,8 @@ for OUT_SIZE in "${OUTPUT_SIZES[@]}"; do
     fi
     # Disable parallelism.
     ENV_FLAGS=OMP_NUM_THREADS=1
-    exec env ${ENV_FLAGS} ${BENCH_RUNNER} ${NUM_ITER} ${OUT_SIZE} ${FUSE_TYPE} ${TYPE} ${TILES[@]} \
-        ${LAYOUT[@]} ${IN_SIZE} ${OUT_SIZE} \
+    exec env ${ENV_FLAGS} ${BENCH_RUNNER} ${NUM_ITER} ${MB} ${FUSE_TYPE} ${TYPE} ${TILES[@]} \
+        ${LAYOUT[@]} ${LAYER} ${LAYER} \
         | sed -nE "s/.*GFLOPS\s+=\s*([0-9.]+).*/\\1/p"
   done
 done

--- a/tools/mlir_bench/mlp_bench.sh
+++ b/tools/mlir_bench/mlp_bench.sh
@@ -62,24 +62,24 @@ if [ "${BASELINE_MODEL}" ] && [ ${IS_DYNAMIC} ]; then
 fi
 
 # Kernel config.
-INPUT_SIZES=( 1024 2048 4096 8192 )
-OUTPUT_SIZES=( 128 256 512 )
+LAYERS=( 1024 2048 4096 8192 )
+MINI_BATCHES=( 128 256 512 )
 if [ ! "${DATA_TYPE}" ]; then
     DATA_TYPE="f32"
 fi
 MODEL_NAME="MLIR_MLP_BENCH.xml"
 
 echo "Result type: time [ms]"
-for OUT_SIZE in "${OUTPUT_SIZES[@]}"; do
-  echo "MLP - OUT: ${OUT_SIZE} INS: ${INPUT_SIZES[@]}"
-  for IN_SIZE in "${INPUT_SIZES[@]}"; do
+for MB in "${MINI_BATCHES[@]}"; do
+  echo "MLP - MB: ${MB} LAYERS: ${LAYERS[@]}"
+  for LAYER in "${LAYERS[@]}"; do
     # Generate model.
     if [ "${BASELINE_MODEL}" ]; then
         # Enable baseline model flag.
-        MODEL_CONFIG=(-b="${BASELINE_MODEL}[${OUT_SIZE},${OUT_SIZE},${IN_SIZE}]")
+        MODEL_CONFIG=(-b="${BASELINE_MODEL}[${MB},${LAYER},${LAYER}]")
     else
         # Generate default PyTorch MLP.
-        MODEL_CONFIG=(-l="linear[${IN_SIZE},${OUT_SIZE}] relu[]")
+        MODEL_CONFIG=(-l="linear[${MB},${LAYER},${LAYER}] relu[]")
     fi
     GEN_FLAGS=(-t ${DATA_TYPE} -n ${MODEL_NAME})
     if [ ${IS_DYNAMIC} ]; then
@@ -97,7 +97,7 @@ for OUT_SIZE in "${OUTPUT_SIZES[@]}"; do
         PRECISION="f16"
     fi
     if [ ${IS_DYNAMIC} ]; then
-        DATA_SHAPE=(-data_shape [${OUT_SIZE},${IN_SIZE}])
+        DATA_SHAPE=(-data_shape [${MB},${LAYER}])
     fi
     # Benchmark config. Disable parallelism.
     PERF_FLAGS="-niter 10000 -hint none -nstreams 1 -nthreads 1"

--- a/tools/mlir_bench/mlp_bench.sh
+++ b/tools/mlir_bench/mlp_bench.sh
@@ -34,21 +34,21 @@ while getopts "t:b:D" arg; do
 done
 
 OV_ROOT=$(git rev-parse --show-toplevel)
-BENCH_ROOT=$(realpath ${OV_ROOT}/tools/mlir_bench)
+BENCH_ROOT=$(realpath "${OV_ROOT}/tools/mlir_bench")
 
-MODEL_GEN=$(realpath ${BENCH_ROOT}/ov_model_gen.py)
+MODEL_GEN=$(realpath "${BENCH_ROOT}/ov_model_gen.py")
 BENCH_RUNNER=benchmark_app
 
 # Initial validation.
-if ! [ -d ${OV_ROOT} ]; then
+if ! [ -d "${OV_ROOT}" ]; then
   echo "Missing OV repo"
   exit 1
 fi
-if ! [ -d ${BENCH_ROOT} ]; then
+if ! [ -d "${BENCH_ROOT}" ]; then
   echo "Missing MLIR benchmark directory"
   exit 1
 fi
-if ! [ -f ${MODEL_GEN} ]; then
+if ! [ -f "${MODEL_GEN}" ]; then
   echo "Missing model generator"
   exit 1
 fi
@@ -56,7 +56,7 @@ if ! [ "$(command -v ${BENCH_RUNNER})" ]; then
   echo "Missing benchmark runner ${BENCH_RUNNER}"
   exit 1
 fi
-if [ "${BASELINE_MODEL}" ] && [ ${IS_DYNAMIC} ]; then
+if [ "${BASELINE_MODEL}" ] && [ "${IS_DYNAMIC}" ]; then
   echo "Baseline models with dynamic shapes not supported"
   exit 1
 fi
@@ -96,13 +96,12 @@ for MB in "${MINI_BATCHES[@]}"; do
         # No native support for bf16, use simple f16 instead.
         PRECISION="f16"
     fi
-    if [ ${IS_DYNAMIC} ]; then
+    if [ "${IS_DYNAMIC}" ]; then
         DATA_SHAPE=(-data_shape [${MB},${LAYER}])
     fi
     # Benchmark config. Disable parallelism.
     PERF_FLAGS="-niter 10000 -hint none -nstreams 1 -nthreads 1"
-    BENCH_FLAGS="-m ${MODEL_NAME} -d CPU \
-        -ip ${PRECISION} ${DATA_SHAPE[@]} ${PERF_FLAGS}"
+    BENCH_FLAGS="-m ${MODEL_NAME} -d CPU -ip ${PRECISION} ${DATA_SHAPE[@]} ${PERF_FLAGS}"
     ${BENCH_RUNNER} ${BENCH_FLAGS} 2>/dev/null | \
         sed -nE "s/.*\[ INFO \]\s*Median:\s*([0-9.]+).*/\\1/p"
   done

--- a/tools/mlir_bench/ov_raw_mlir_bench.sh
+++ b/tools/mlir_bench/ov_raw_mlir_bench.sh
@@ -64,24 +64,24 @@ if [ ${IS_DYNAMIC} ]; then
 fi
 
 # Kernel config.
-INPUT_SIZES=( 1024 2048 4096 8192 )
-OUTPUT_SIZES=( 128 256 512 )
+LAYERS=( 1024 2048 4096 8192 )
+MINI_BATCHES=( 128 256 512 )
 if [ ! "${DATA_TYPE}" ]; then
     DATA_TYPE="f32"
 fi
 MODEL_NAME="TPP_BENCH.xml"
 
 echo "Result type: time [ns]"
-for OUT_SIZE in "${OUTPUT_SIZES[@]}"; do
-  echo "MLP - OUT: ${OUT_SIZE} INS: ${INPUT_SIZES[@]}"
-  for IN_SIZE in "${INPUT_SIZES[@]}"; do
+for MB in "${MINI_BATCHES[@]}"; do
+  echo "MLP - MB: ${MB} LAYERS: ${LAYERS[@]}"
+  for LAYER in "${LAYERS[@]}"; do
     # Generate model.
     if [ "${BASELINE_MODEL}" ]; then
         # Enable baseline model flag.
-        MODEL_CONFIG=(-b="${BASELINE_MODEL}[${OUT_SIZE},${OUT_SIZE},${IN_SIZE}]")
+        MODEL_CONFIG=(-b="${BASELINE_MODEL}[${MB},${LAYER},${LAYER}]")
     else
         # Generate default PyTorch MLP.
-        MODEL_CONFIG=(-l="linear[${IN_SIZE},${OUT_SIZE}] relu[]")
+        MODEL_CONFIG=(-l="linear[${MB},${LAYER},${LAYER}] relu[]")
     fi
     GEN_FLAGS=(-t ${DATA_TYPE} -n ${MODEL_NAME})
     GEN_FLAGS+=(-p)

--- a/tools/mlir_bench/tpp_mlir_bench.sh
+++ b/tools/mlir_bench/tpp_mlir_bench.sh
@@ -47,25 +47,18 @@ if [ ${IS_DYNAMIC} ]; then
 fi
 
 # Kernel config.
-INPUT_SIZES=( 1024 2048 4096 8192 )
-OUTPUT_SIZES=( 128 256 512 )
+LAYERS=( 1024 2048 4096 8192 )
+MINI_BATCHES=( 128 256 512 )
 if [ ! "${DATA_TYPE}" ]; then
     DATA_TYPE="f32"
 fi
 
 echo "Result type: time [ns]"
-for OUT_SIZE in "${OUTPUT_SIZES[@]}"; do
-  echo "MLP - OUT: ${OUT_SIZE} INS: ${INPUT_SIZES[@]}"
-  for IN_SIZE in "${INPUT_SIZES[@]}"; do
+for MB in "${MINI_BATCHES[@]}"; do
+  echo "MLP - MB: ${MB} LAYERS: ${LAYERS[@]}"
+  for LAYER in "${LAYERS[@]}"; do
     # Generate model.
-    if [ "${BASELINE_MODEL}" ]; then
-        # Enable baseline model flag.
-        MODEL_CONFIG=(-b="${BASELINE_MODEL}[${OUT_SIZE},${OUT_SIZE},${IN_SIZE}]")
-    else
-        # Generate default PyTorch MLP.
-        MODEL_CONFIG=(-l="linear[${IN_SIZE},${OUT_SIZE}] relu[]")
-    fi
-    MODEL_CONFIG=(--batch=${OUT_SIZE} --layers=${IN_SIZE},${OUT_SIZE} -bias -relu)
+    MODEL_CONFIG=(--batch=${MB} --layers=${LAYER},${LAYER} -bias -relu)
     GEN_FLAGS=(--kernel=args --float-type=${DATA_TYPE} --seed=123)
     MLIR_IR=$(${MODEL_GEN} "${MODEL_CONFIG[@]}" "${GEN_FLAGS[@]}")
     if [ $? != 0 ]; then


### PR DESCRIPTION
Resizes MLP benchmarks to align with existing MLIR tests.
Tweaks model generator to expose full control over M,N,K dimensions of torch Linear layer.