### PR TITLE
TPP const weights and benchmark runners

### DIFF
--- a/tools/mlir_bench/run_bench_bf16.sh
+++ b/tools/mlir_bench/run_bench_bf16.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+echo "### MLP BF16 benchmarks ###"
+echo "LIBXSMM"
+../tools/mlir_bench/libxsmm_bench.sh -B
+echo "TPP-MLIR args weights"
+../tools/mlir_bench/tpp_mlir_bench.sh -t bf16
+
+echo ""
+echo "Baseline MLP"
+echo "OV - no MLIR - baseline model"
+OV_MLIR=0 ../tools/mlir_bench/mlp_bench.sh -t bf16 -b mlp
+echo "OV + MLIR - kernel only - baseline model"
+../tools/mlir_bench/ov_raw_mlir_bench.sh -t bf16 -b mlp
+echo "OV + MLIR - full - baseline model"
+OV_MLIR=1 ../tools/mlir_bench/mlp_bench.sh -t bf16 -b mlp
+
+echo ""
+echo "PyTorch MLP"
+echo "OV - no MLIR - PyTorch"
+OV_MLIR=0 ../tools/mlir_bench/mlp_bench.sh -t bf16
+echo "OV + MLIR - kernel only - PyTorch"
+../tools/mlir_bench/ov_raw_mlir_bench.sh -t bf16
+echo "OV + MLIR - full - PyTorch"
+OV_MLIR=1 ../tools/mlir_bench/mlp_bench.sh -t bf16
+
+echo "TPP-MLIR const weights"
+../tools/mlir_bench/tpp_mlir_bench.sh -t bf16 -C

--- a/tools/mlir_bench/run_bench_f32.sh
+++ b/tools/mlir_bench/run_bench_f32.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+echo "### MLP F32 benchmarks ###"
+echo "LIBXSMM"
+../tools/mlir_bench/libxsmm_bench.sh
+echo "TPP-MLIR args weights"
+../tools/mlir_bench/tpp_mlir_bench.sh -t f32
+
+echo ""
+echo "Baseline MLP"
+echo "OV - no MLIR - baseline model"
+OV_MLIR=0 ../tools/mlir_bench/mlp_bench.sh -t f32 -b mlp
+echo "OV + MLIR - kernel only - baseline model"
+../tools/mlir_bench/ov_raw_mlir_bench.sh -t f32 -b mlp
+echo "OV + MLIR - full - baseline model"
+OV_MLIR=1 ../tools/mlir_bench/mlp_bench.sh -t f32 -b mlp
+
+echo ""
+echo "PyTorch MLP"
+echo "OV - no MLIR - PyTorch"
+OV_MLIR=0 ../tools/mlir_bench/mlp_bench.sh -t f32
+echo "OV + MLIR - kernel only - PyTorch"
+../tools/mlir_bench/ov_raw_mlir_bench.sh -t f32
+echo "OV + MLIR - full - PyTorch"
+OV_MLIR=1 ../tools/mlir_bench/mlp_bench.sh -t f32
+
+echo "TPP-MLIR const weights"
+../tools/mlir_bench/tpp_mlir_bench.sh -t f32 -C


### PR DESCRIPTION
Adds option for TPP-MLIR benchmark with weights as constants which enables compile-time packing.
Also, add utility benchmark runners.