### PR TITLE
[GraphCompiler] Use find_package() for CMake < 3.24

### DIFF
--- a/cmake/graph-compiler.cmake
+++ b/cmake/graph-compiler.cmake
@@ -1,24 +1,32 @@
 get_property(GRAPH_COMPILER_LIBS GLOBAL PROPERTY GRAPH_COMPILER_LIBS)
 if (NOT DEFINED GRAPH_COMPILER_LIBS)
-    include(FetchContent)
+    # The FetchContent_Declare(FIND_PACKAGE_ARGS) is supported since CMake 3.24. For the prior
+    # versions, using find_package() first. If the package is not found, then using FetchContent.
+    if (CMAKE_VERSION VERSION_LESS "3.24")
+        find_package(GraphCompiler QUIET)
+    endif ()
 
-    #FIXME: Replace the repository URL with the https://github.com/intel/graph-compiler
-    FetchContent_Declare(
-            GC
-            GIT_REPOSITORY https://github.com/AndreyPavlenko/graph-compiler.git
-            GIT_TAG pkg
-            FIND_PACKAGE_ARGS NAMES GraphCompiler
-    )
+    if (NOT GraphCompiler_FOUND)
+        include(FetchContent)
 
-    set(GC_ENABLE_OPT OFF)
-    set(GC_ENABLE_TEST OFF)
-    set(GC_ENABLE_DNNL OFF)
-    set(GC_ENABLE_LEGACY OFF)
-    set(GC_ENABLE_BINDINGS_PYTHON OFF)
-    set(OV_BUILD_SHARED_LIBS_TMP ${BUILD_SHARED_LIBS})
-    set(BUILD_SHARED_LIBS OFF)
-    FetchContent_MakeAvailable(GC)
-    set(BUILD_SHARED_LIBS ${OV_BUILD_SHARED_LIBS_TMP})
+        #FIXME: Replace the repository URL with the https://github.com/intel/graph-compiler
+        FetchContent_Declare(
+                GC
+                GIT_REPOSITORY https://github.com/AndreyPavlenko/graph-compiler.git
+                GIT_TAG pkg
+                FIND_PACKAGE_ARGS NAMES GraphCompiler
+        )
+
+        set(GC_ENABLE_OPT OFF)
+        set(GC_ENABLE_TEST OFF)
+        set(GC_ENABLE_DNNL OFF)
+        set(GC_ENABLE_LEGACY OFF)
+        set(GC_ENABLE_BINDINGS_PYTHON OFF)
+        set(OV_BUILD_SHARED_LIBS_TMP ${BUILD_SHARED_LIBS})
+        set(BUILD_SHARED_LIBS OFF)
+        FetchContent_MakeAvailable(GC)
+        set(BUILD_SHARED_LIBS ${OV_BUILD_SHARED_LIBS_TMP})
+    endif ()
 
     set(GRAPH_COMPILER_LIBS
             GcInterface

--- a/cmake/graph-compiler.cmake
+++ b/cmake/graph-compiler.cmake
@@ -9,11 +9,10 @@ if (NOT DEFINED GRAPH_COMPILER_LIBS)
     if (NOT GraphCompiler_FOUND)
         include(FetchContent)
 
-        #FIXME: Replace the repository URL with the https://github.com/intel/graph-compiler
         FetchContent_Declare(
                 GC
-                GIT_REPOSITORY https://github.com/AndreyPavlenko/graph-compiler.git
-                GIT_TAG pkg
+                GIT_REPOSITORY https://github.com/intel/graph-compiler.git
+                GIT_TAG main
                 FIND_PACKAGE_ARGS NAMES GraphCompiler
         )
 


### PR DESCRIPTION
The FetchContent_Declare(FIND_PACKAGE_ARGS) is supported since CMake 3.24. For the prior versions, using find_package() first. If the package is not found, then using FetchContent.