### PR TITLE
Unify bench configs

### DIFF
--- a/tools/mlir_bench/libxsmm_bench.sh
+++ b/tools/mlir_bench/libxsmm_bench.sh
@@ -6,21 +6,25 @@
 # Runs MLP benchmarks using libxsmm.
 
 die_syntax() {
-  echo "Syntax: $0 [-B] [-D]"
+  echo "Syntax: $0 [-B] [-D] [-l 3]"
   echo ""
   echo "  -B: Use bf16 data type"
+  echo "  -l: Optional number of layers (def:3)"
   echo "  -D: Set model shapes to dynamic"
   exit 1
 }
 
 # Cmd-line opts
-while getopts "BD" arg; do
+while getopts "l:BD" arg; do
   case ${arg} in
     B)
       DATA_TYPE="bf16"
       ;;
     D)
       IS_DYNAMIC=true
+      ;;
+    l)
+      NUM_LAYERS=${OPTARG}
       ;;
     ?)
       echo "Invalid option: ${OPTARG}"
@@ -42,13 +46,18 @@ if [ "${IS_DYNAMIC}" ]; then
 fi
 
 # Kernel config.
-LAYERS=( 1024 2048 4096 8192 )
-MINI_BATCHES=( 128 256 512 )
+#LAYERS=( 1024 2048 4096 8192 )
+#MINI_BATCHES=( 128 256 512 )
+LAYERS=( 1024 )
+MINI_BATCHES=( 256 )
 if [ ! "${DATA_TYPE}" ]; then
     DATA_TYPE="f32"
 fi
+if [ ! $NUM_LAYERS ]; then
+  NUM_LAYERS=3
+fi
 
-echo "Result type: GFLOPS"
+echo "Result type: GFLOPS - NUM LAYERS: ${NUM_LAYERS}"
 for MB in "${MINI_BATCHES[@]}"; do
   echo "MLP - MB: ${MB} LAYERS: ${LAYERS[@]}"
   for LAYER in "${LAYERS[@]}"; do
@@ -61,10 +70,14 @@ for MB in "${MINI_BATCHES[@]}"; do
     if [ "${DATA_TYPE}" = "bf16" ]; then
         LAYOUT=(1 1)
     fi
+    LAYER_STRING="${LAYER}"
+    for i in $(seq ${NUM_LAYERS}); do
+      LAYER_STRING="${LAYER_STRING} ${LAYER}"
+    done
     # Disable parallelism.
     ENV_FLAGS=OMP_NUM_THREADS=1
     exec env ${ENV_FLAGS} ${BENCH_RUNNER} ${NUM_ITER} ${MB} ${FUSE_TYPE} ${TYPE} ${TILES[@]} \
-        ${LAYOUT[@]} ${LAYER} ${LAYER} \
+        ${LAYOUT[@]} ${LAYER_STRING} \
         | sed -nE "s/.*GFLOPS\s+=\s*([0-9.]+).*/\\1/p"
   done
 done

--- a/tools/mlir_bench/mlp_bench.sh
+++ b/tools/mlir_bench/mlp_bench.sh
@@ -6,7 +6,7 @@
 # Runs OV MLP benchmarks.
 
 die_syntax() {
-  echo "Syntax: $0 [-t (f32|f16|bf16|...)] [-b (mlp)] [-D]"
+  echo "Syntax: $0 [-t (f32|f16|bf16|...)] [-b (mlp)] [-D] [-l 3]"
   echo ""
   echo "  -t: Optional data type"
   echo "  -b: Optional baseline model"
@@ -79,7 +79,7 @@ if [ ! "${DATA_TYPE}" ]; then
 fi
 MODEL_NAME="MLIR_MLP_BENCH.xml"
 
-echo "Result type: time [ms]"
+echo "Result type: time [ms] - NUM LAYERS: ${NUM_LAYERS}"
 for MB in "${MINI_BATCHES[@]}"; do
   echo "MLP - MB: ${MB} LAYERS: ${LAYERS[@]}"
   for LAYER in "${LAYERS[@]}"; do

--- a/tools/mlir_bench/ov_raw_mlir_bench.sh
+++ b/tools/mlir_bench/ov_raw_mlir_bench.sh
@@ -8,22 +8,26 @@
 # For example, the whole graph is outlined to MLIR.
 
 die_syntax() {
-  echo "Syntax: $0 [-t (f32|f16|bf16|...)] [-b (mlp)] [-D]"
+  echo "Syntax: $0 [-t (f32|f16|bf16|...)] [-b (mlp)] [-D] [-l 3]"
   echo ""
   echo "  -t: Optional data type"
   echo "  -b: Optional baseline model"
+  echo "  -l: Optional number of layers (def:3)"
   echo "  -D: Set model shapes to dynamic"
   exit 1
 }
 
 # Cmd-line opts
-while getopts "t:b:D" arg; do
+while getopts "t:b:l:D" arg; do
   case ${arg} in
     t)
       DATA_TYPE=${OPTARG}
       ;;
     b)
       BASELINE_MODEL=${OPTARG}
+      ;;
+    l)
+      NUM_LAYERS=${OPTARG}
       ;;
     D)
       IS_DYNAMIC=true
@@ -64,25 +68,35 @@ if [ "${IS_DYNAMIC}" ]; then
 fi
 
 # Kernel config.
-LAYERS=( 1024 2048 4096 8192 )
-MINI_BATCHES=( 128 256 512 )
+# LAYERS=( 1024 2048 4096 8192 )
+# MINI_BATCHES=( 128 256 512 )
+LAYERS=( 1024 )
+MINI_BATCHES=( 256 )
 if [ ! "${DATA_TYPE}" ]; then
     DATA_TYPE="f32"
 fi
+if [ ! $NUM_LAYERS ]; then
+  NUM_LAYERS=3
+fi
 MODEL_NAME="TPP_BENCH.xml"
 
-echo "Result type: time [s]"
+echo "Result type: time [s] - NUM LAYERS: ${NUM_LAYERS}"
 for MB in "${MINI_BATCHES[@]}"; do
   echo "MLP - MB: ${MB} LAYERS: ${LAYERS[@]}"
   for LAYER in "${LAYERS[@]}"; do
     # Generate model.
     if [ "${BASELINE_MODEL}" ]; then
         # Enable baseline model flag.
-        MODEL_CONFIG=(-b="${BASELINE_MODEL}[${MB},${LAYER},${LAYER}]")
+        MODEL_CONFIG=(-b="${BASELINE_MODEL}[${MB},${LAYER},${LAYER}]x${NUM_LAYERS}")
     else
         # Generate default PyTorch MLP.
-        MODEL_CONFIG=(-l="linear[${MB},${LAYER},${LAYER}] relu[]")
+        LAYER_STRING="linear[${MB},${LAYER},${LAYER}] relu[]"
+        for i in $(seq ${NUM_LAYERS}); do
+          MODEL_STRING="${MODEL_STRING}${LAYER_STRING} "
+        done
+        MODEL_CONFIG=(-l="${MODEL_STRING}")
     fi
+    echo "MODEL_CONFIG=${MODEL_CONFIG}"
     GEN_FLAGS=(-t ${DATA_TYPE} -n ${MODEL_NAME})
     GEN_FLAGS+=(-p)
     ENV_FLAGS=OV_MLIR_TPP=0

--- a/tools/mlir_bench/ov_raw_mlir_bench.sh
+++ b/tools/mlir_bench/ov_raw_mlir_bench.sh
@@ -99,7 +99,7 @@ for MB in "${MINI_BATCHES[@]}"; do
     echo "MODEL_CONFIG=${MODEL_CONFIG}"
     GEN_FLAGS=(-t ${DATA_TYPE} -n ${MODEL_NAME})
     GEN_FLAGS+=(-p)
-    ENV_FLAGS=OV_MLIR_TPP=0
+    ENV_FLAGS="OV_MLIR_TPP=0 OV_MLIR_DEBUG=1"
     MODEL_OUT=$(exec env ${ENV_FLAGS} python3 ${MODEL_GEN} "${MODEL_CONFIG[@]}" "${GEN_FLAGS[@]}" 2>&1)
     if [ $? != 0 ]; then
         echo "Failed to generate model"

--- a/tools/mlir_bench/run_bench_bf16.sh
+++ b/tools/mlir_bench/run_bench_bf16.sh
@@ -24,6 +24,8 @@ if [ ! "${NUM_LAYERS}" ]; then
   NUM_LAYERS=3
 fi
 
+export OV_MLIR_DEBUG=1
+
 echo "### MLP BF16 benchmarks ###"
 echo "# Layers: ${NUM_LAYERS} #"
 echo "LIBXSMM"

--- a/tools/mlir_bench/run_bench_bf16.sh
+++ b/tools/mlir_bench/run_bench_bf16.sh
@@ -1,28 +1,53 @@
 #!/bin/bash
 
+die_syntax() {
+  echo "Syntax: $0 [-l 3]"
+  echo ""
+  echo "  -l: Optional number of layers (def: 3)"
+  exit 1
+}
+
+# Cmd-line opts
+while getopts "l:" arg; do
+  case ${arg} in
+    l)
+      NUM_LAYERS=${OPTARG}
+      ;;
+    ?)
+      echo "Invalid option: ${OPTARG}"
+      die_syntax
+      ;;
+  esac
+done
+
+if [ ! "${NUM_LAYERS}" ]; then
+  NUM_LAYERS=3
+fi
+
 echo "### MLP BF16 benchmarks ###"
+echo "# Layers: ${NUM_LAYERS} #"
 echo "LIBXSMM"
-../tools/mlir_bench/libxsmm_bench.sh -B
+../tools/mlir_bench/libxsmm_bench.sh -B -l ${NUM_LAYERS}
 echo "TPP-MLIR args weights"
-../tools/mlir_bench/tpp_mlir_bench.sh -t bf16
+../tools/mlir_bench/tpp_mlir_bench.sh -t bf16 -l ${NUM_LAYERS}
 
 echo ""
 echo "Baseline MLP"
 echo "OV - no MLIR - baseline model"
-OV_MLIR=0 ../tools/mlir_bench/mlp_bench.sh -t bf16 -b mlp
+OV_MLIR=0 ../tools/mlir_bench/mlp_bench.sh -t bf16 -b mlp -l ${NUM_LAYERS}
 echo "OV + MLIR - kernel only - baseline model"
-../tools/mlir_bench/ov_raw_mlir_bench.sh -t bf16 -b mlp
+../tools/mlir_bench/ov_raw_mlir_bench.sh -t bf16 -b mlp -l ${NUM_LAYERS}
 echo "OV + MLIR - full - baseline model"
-OV_MLIR=1 ../tools/mlir_bench/mlp_bench.sh -t bf16 -b mlp
+OV_MLIR=1 ../tools/mlir_bench/mlp_bench.sh -t bf16 -b mlp -l ${NUM_LAYERS}
 
 echo ""
 echo "PyTorch MLP"
 echo "OV - no MLIR - PyTorch"
-OV_MLIR=0 ../tools/mlir_bench/mlp_bench.sh -t bf16
+OV_MLIR=0 ../tools/mlir_bench/mlp_bench.sh -t bf16 -l ${NUM_LAYERS}
 echo "OV + MLIR - kernel only - PyTorch"
-../tools/mlir_bench/ov_raw_mlir_bench.sh -t bf16
+../tools/mlir_bench/ov_raw_mlir_bench.sh -t bf16 -l ${NUM_LAYERS}
 echo "OV + MLIR - full - PyTorch"
-OV_MLIR=1 ../tools/mlir_bench/mlp_bench.sh -t bf16
+OV_MLIR=1 ../tools/mlir_bench/mlp_bench.sh -t bf16 -l ${NUM_LAYERS}
 
 echo "TPP-MLIR const weights"
-../tools/mlir_bench/tpp_mlir_bench.sh -t bf16 -C
+../tools/mlir_bench/tpp_mlir_bench.sh -t bf16 -C -l ${NUM_LAYERS}

--- a/tools/mlir_bench/run_bench_f32.sh
+++ b/tools/mlir_bench/run_bench_f32.sh
@@ -24,6 +24,8 @@ if [ ! "${NUM_LAYERS}" ]; then
   NUM_LAYERS=3
 fi
 
+export OV_MLIR_DEBUG=1
+
 echo "### MLP F32 benchmarks ###"
 echo "# Layers: ${NUM_LAYERS} #"
 echo "LIBXSMM"

--- a/tools/mlir_bench/run_bench_f32.sh
+++ b/tools/mlir_bench/run_bench_f32.sh
@@ -1,28 +1,53 @@
 #!/bin/bash
 
+die_syntax() {
+  echo "Syntax: $0 [-l 3]"
+  echo ""
+  echo "  -l: Optional number of layers (def: 3)"
+  exit 1
+}
+
+# Cmd-line opts
+while getopts "l:" arg; do
+  case ${arg} in
+    l)
+      NUM_LAYERS=${OPTARG}
+      ;;
+    ?)
+      echo "Invalid option: ${OPTARG}"
+      die_syntax
+      ;;
+  esac
+done
+
+if [ ! "${NUM_LAYERS}" ]; then
+  NUM_LAYERS=3
+fi
+
 echo "### MLP F32 benchmarks ###"
+echo "# Layers: ${NUM_LAYERS} #"
 echo "LIBXSMM"
-../tools/mlir_bench/libxsmm_bench.sh
+../tools/mlir_bench/libxsmm_bench.sh -l ${NUM_LAYERS}
 echo "TPP-MLIR args weights"
-../tools/mlir_bench/tpp_mlir_bench.sh -t f32
+../tools/mlir_bench/tpp_mlir_bench.sh -t f32 -l ${NUM_LAYERS}
 
 echo ""
 echo "Baseline MLP"
 echo "OV - no MLIR - baseline model"
-OV_MLIR=0 ../tools/mlir_bench/mlp_bench.sh -t f32 -b mlp
+OV_MLIR=0 ../tools/mlir_bench/mlp_bench.sh -t f32 -b mlp -l ${NUM_LAYERS}
 echo "OV + MLIR - kernel only - baseline model"
-../tools/mlir_bench/ov_raw_mlir_bench.sh -t f32 -b mlp
+../tools/mlir_bench/ov_raw_mlir_bench.sh -t f32 -b mlp -l ${NUM_LAYERS}
 echo "OV + MLIR - full - baseline model"
-OV_MLIR=1 ../tools/mlir_bench/mlp_bench.sh -t f32 -b mlp
+OV_MLIR=1 ../tools/mlir_bench/mlp_bench.sh -t f32 -b mlp -l ${NUM_LAYERS}
 
 echo ""
 echo "PyTorch MLP"
 echo "OV - no MLIR - PyTorch"
-OV_MLIR=0 ../tools/mlir_bench/mlp_bench.sh -t f32
+OV_MLIR=0 ../tools/mlir_bench/mlp_bench.sh -t f32 -l ${NUM_LAYERS}
 echo "OV + MLIR - kernel only - PyTorch"
-../tools/mlir_bench/ov_raw_mlir_bench.sh -t f32
+../tools/mlir_bench/ov_raw_mlir_bench.sh -t f32 -l ${NUM_LAYERS}
 echo "OV + MLIR - full - PyTorch"
-OV_MLIR=1 ../tools/mlir_bench/mlp_bench.sh -t f32
+OV_MLIR=1 ../tools/mlir_bench/mlp_bench.sh -t f32 -l ${NUM_LAYERS}
 
 echo "TPP-MLIR const weights"
-../tools/mlir_bench/tpp_mlir_bench.sh -t f32 -C
+../tools/mlir_bench/tpp_mlir_bench.sh -t f32 -l ${NUM_LAYERS}

--- a/tools/mlir_bench/run_bench_f32.sh
+++ b/tools/mlir_bench/run_bench_f32.sh
@@ -50,4 +50,4 @@ echo "OV + MLIR - full - PyTorch"
 OV_MLIR=1 ../tools/mlir_bench/mlp_bench.sh -t f32 -l ${NUM_LAYERS}
 
 echo "TPP-MLIR const weights"
-../tools/mlir_bench/tpp_mlir_bench.sh -t f32 -l ${NUM_LAYERS}
+../tools/mlir_bench/tpp_mlir_bench.sh -t f32 -C -l ${NUM_LAYERS}


### PR DESCRIPTION
Adjusts all MLIR benchmarks to follow recent `mlp_bench` changes.
Adds and propagates control for number of MLP layers to be measured.
Sets environment variable to enable MLIR IR dump from OV.