### PR TITLE
Fix python execution in GC_GPU mode

### DIFF
--- a/cmake/graph-compiler.cmake
+++ b/cmake/graph-compiler.cmake
@@ -25,9 +25,14 @@ if (NOT DEFINED GRAPH_COMPILER_LIBS)
         set(GC_ENABLE_LEGACY OFF)
         set(GC_ENABLE_BINDINGS_PYTHON OFF)
         set(OV_BUILD_SHARED_LIBS_TMP ${BUILD_SHARED_LIBS})
-        set(BUILD_SHARED_LIBS OFF)
+        set(BUILD_SHARED_LIBS ON)
         FetchContent_MakeAvailable(GC)
         set(BUILD_SHARED_LIBS ${OV_BUILD_SHARED_LIBS_TMP})
+        FetchContent_GetProperties(GC BINARY_DIR gc_BINARY_DIR)
+        find_library(GC_CPU_RUNTIME_PATH GcCpuRuntime)
+        install(FILES ${GC_CPU_RUNTIME_PATH} DESTINATION ${OV_CPACK_RUNTIMEDIR})
+        # a hack to not bother with actual file extension
+        install(FILES ${GC_CPU_RUNTIME_PATH}.20.0git DESTINATION ${OV_CPACK_RUNTIMEDIR})
     endif ()
 
     set(GRAPH_COMPILER_LIBS

--- a/src/bindings/python/wheel/CMakeLists.txt
+++ b/src/bindings/python/wheel/CMakeLists.txt
@@ -8,10 +8,21 @@
 
 execute_process(COMMAND ${Python3_EXECUTABLE} -c "import wheel.vendored.packaging.tags as tags ; print(f'{tags.interpreter_name()}{tags.interpreter_version()}')"
                 OUTPUT_VARIABLE PYTHON_TAG OUTPUT_STRIP_TRAILING_WHITESPACE)
-execute_process(COMMAND ${Python3_EXECUTABLE} -c "import wheel.bdist_wheel ; print(f'{wheel.bdist_wheel.get_abi_tag()}')"
+if(NOT PYTHON_TAG)
+    message(FATAL_ERROR "Failed to detect Python Tag via wheel.vendored.packaging.tags. Please, check 'wheel' dependency version update")
+endif()
+
+execute_process(COMMAND ${Python3_EXECUTABLE} -c "from setuptools.command.bdist_wheel import get_abi_tag; print(f'{get_abi_tag()}')"
                 OUTPUT_VARIABLE ABI_TAG OUTPUT_STRIP_TRAILING_WHITESPACE)
+if(NOT ABI_TAG)
+    message(FATAL_ERROR "Failed to detect ABI Tag via setuptools.command.bdist_wheel. Please, check 'setuptools' dependency version update")
+endif()
+
 execute_process(COMMAND ${Python3_EXECUTABLE} -c "import wheel.vendored.packaging.tags as tags ; print(f'{next(tags.platform_tags())}')"
                 OUTPUT_VARIABLE PLATFORM_TAG OUTPUT_STRIP_TRAILING_WHITESPACE)
+if(NOT PLATFORM_TAG)
+    message(FATAL_ERROR "Failed to detect Platform Tag via wheel.vendored.packaging.tags. Please, check 'wheel' dependency version update")
+endif()
 
 # defines wheel architecture part of `PLATFORM_TAG`
 macro(_ov_platform_arch)


### PR DESCRIPTION
This cherry-picks a solution for python wheel installation problem, fixes the missing GC CPU runtime shared library, and replaces an incorrect call to `get_input_shape` to support dynamic shapes.