### PR TITLE
i32 index fixes

### DIFF
--- a/src/common/transformations/src/transformations/mlir/op/gather.cpp
+++ b/src/common/transformations/src/transformations/mlir/op/gather.cpp
@@ -61,13 +61,15 @@ struct ConvertGather {
         auto empty_add = builder.create<tensor::EmptyOp>(loc, indices_expanded.getType(), dynamic_index_dims);
         auto add = builder.create<linalg::AddOp>(loc, mlir::ValueRange{cast.getResult(), indices_expanded}, mlir::ValueRange{empty_add});
         auto select = builder.create<linalg::SelectOp>(loc, mlir::ValueRange{cmpi.getResult(), add.getResult(0), indices_expanded}, mlir::ValueRange{empty_add});
+        auto index_type = RankedTensorType::get(ArrayRef(importShape(ov_output_shape)), builder.getIndexType());
+        auto cast2 = builder.create<arith::IndexCastOp>(loc, index_type, mlir::ValueRange{select.getResult(0)});
 
         auto gather_node = std::dynamic_pointer_cast<ov::op::util::GatherBase>(node);
         assert(gather_node && "Expected a gather node");
         int64_t axis = gather_node->get_axis();
 
         llvm::SmallVector<int64_t> gather_dims{axis};
-        auto gather = builder.create<tensor::GatherOp>(loc, out_type, input, select.getResult(0), gather_dims, false);
+        auto gather = builder.create<tensor::GatherOp>(loc, out_type, input, cast2, gather_dims, false);
         context.addOutputs(node, gather);
     }
 };

--- a/src/common/transformations/src/transformations/mlir/op/transpose.cpp
+++ b/src/common/transformations/src/transformations/mlir/op/transpose.cpp
@@ -27,11 +27,19 @@ struct ConvertTranspose {
         const auto ov_output_shape = node->get_output_partial_shape(0);
         auto out_type = importTensor(context.context, ov_output_shape, ov_output_element_type);
         auto dynamic_dimensions = context.get_dynamic_dimension_values(ov_output_shape);
+        const auto ov_order_element_type = node->get_input_element_type(1);
 
         auto const_order = dynamic_cast<ov::op::v0::Constant*>(node->get_input_node_ptr(1));
         assert(const_order && "non-const order not supported");
-        ov::Coordinate coords = const_order->get_coordinate_val();
-        SmallVector<int64_t> order(coords.begin(), coords.end());
+        SmallVector<int64_t> order;
+        if (ov_order_element_type == ov::element::i64) {
+            ov::Coordinate coords = const_order->get_coordinate_val();
+            order.assign(coords.begin(), coords.end());
+        } else {
+            assert(ov_order_element_type == ov::element::i32);
+            std::vector<int32_t> coords = const_order->get_vector<int32_t>();
+            order.assign(coords.begin(), coords.end());
+        }
 
         auto empty = builder.create<tensor::EmptyOp>(loc, out_type, dynamic_dimensions);
         auto transpose = builder.create<linalg::TransposeOp>(loc, input, empty, order);

--- a/src/common/transformations/src/transformations/mlir/op/transpose.cpp
+++ b/src/common/transformations/src/transformations/mlir/op/transpose.cpp
@@ -31,15 +31,8 @@ struct ConvertTranspose {
 
         auto const_order = dynamic_cast<ov::op::v0::Constant*>(node->get_input_node_ptr(1));
         assert(const_order && "non-const order not supported");
-        SmallVector<int64_t> order;
-        if (ov_order_element_type == ov::element::i64) {
-            ov::Coordinate coords = const_order->get_coordinate_val();
-            order.assign(coords.begin(), coords.end());
-        } else {
-            assert(ov_order_element_type == ov::element::i32);
-            std::vector<int32_t> coords = const_order->get_vector<int32_t>();
-            order.assign(coords.begin(), coords.end());
-        }
+        std::vector<int64_t> coords = const_order->cast_vector<int64_t>();
+        SmallVector<int64_t> order(coords.begin(), coords.end());
 
         auto empty = builder.create<tensor::EmptyOp>(loc, out_type, dynamic_dimensions);
         auto transpose = builder.create<linalg::TransposeOp>(loc, input, empty, order);


### PR DESCRIPTION
These are what I have found while experimenting with different small models. When the type of an index is i32 it doesn't fit into an mlir op and there might be problems with accessing them through the constant op on OV side (I'd seen partial data for example). There are quick fixes for the issues I've seen so far.